### PR TITLE
some formatting fixes

### DIFF
--- a/docs/cm-file.md
+++ b/docs/cm-file.md
@@ -18,7 +18,9 @@ An automation identifier is a composition of the CM file name and the automation
 
 !!! tip
 
-    You can exclude certain repositories per automation file using the [`config.ignore_repositories`](#config)
+```text
+You can exclude certain repositories per automation file using the [`config.ignore_repositories`](#config)
+```
 
 ### Repository automation rules
 
@@ -45,7 +47,9 @@ When configured correctly, your repository directory structure should look like 
 
 !!! note
 
-    The `.cm/gitstream.cm` is special, as it allows for repository level configuration such as `config.admin`.
+```text
+The `.cm/gitstream.cm` is special, as it allows for repository level configuration such as `config.admin`.
+```
 
 ### Organization automation rules
 

--- a/docs/cm-file.md
+++ b/docs/cm-file.md
@@ -6,23 +6,23 @@ You can edit the `.cm` files and add your own checks and rules. Check out the [A
 
 ## Automation rules
 
-There are two types of automation rules: repository level rules and organization level rules. 
+There are two types of automation rules: repository level rules and organization level rules.
 
-Repository level rules are set by creating a special `.cm` directory in the repository root. Automation rules are specified in files in this directory, which can have any name but must end with `.cm`. 
+Repository level rules are set by creating a special `.cm` directory in the repository root. Automation rules are specified in files in this directory, which can have any name but must end with `.cm`.
 
-Organization level rules are defined by creating a special repository named `cm` in the organization or group. In this repository, you can add CM automation files, which will apply to all the repositories that gitStream app is connected. 
+Organization level rules are defined by creating a special repository named `cm` in the organization or group. In this repository, you can add CM automation files, which will apply to all the repositories that gitStream app is connected.
 
 **When organization level rules are defines, repository level automation shall take precedence and override organization automation when having the same identifier.**
 
-An autoamtion identifier is a compistion of the CM file name and the automation name. For example when `safe_changes` is defined in `gitstream.cm` then the automation identifier shall be `gitstream/safe_changes`
+An automation identifier is a composition of the CM file name and the automation name. For example when `safe_changes` is defined in `gitstream.cm` then the automation identifier shall be `gitstream/safe_changes`
 
-!!! tip 
+!!! tip
 
-    You can exclude certain repositoires per automation file using the [`config.ignore_repositories`](#config)
+    You can exclude certain repositories per automation file using the [`config.ignore_repositories`](#config)
 
 ### Repository automation rules
 
-Repository automation rules are set by creating a special `.cm` directory in your repository root. Automation rules are specified in files in this directory, these files can have any name but ends with `.cm`. By default, you start with a single automation file `.cm/gitstream.cm`. 
+Repository automation rules are set by creating a special `.cm` directory in your repository root. Automation rules are specified in files in this directory, these files can have any name but must end with `.cm`. By default, you start with a single automation file `.cm/gitstream.cm`.
 
 Every file is parsed independently, and the parsing results are combined and executed.
 
@@ -43,7 +43,7 @@ When configured correctly, your repository directory structure should look like 
 │     └─ gitstream.yml
 ```
 
-!!! note 
+!!! note
 
     The `.cm/gitstream.cm` is special, as it allows for repository level configuration such as `config.admin`.
 
@@ -63,7 +63,7 @@ When configured correctly, the `cm` repository directory structure should look l
 
 For each PR the following automation rules are applied:
 
-1. Repository level rules 
+1. Repository level rules
 2. Organization level rules, unless with the same identifier as a repository level automation
 
 When organization level rules are defined, then the CI/CD will be executed on the `cm` repository on behalf of the PR repository.
@@ -85,7 +85,7 @@ See more about the Nunjucks built-in filters [here](https://mozilla.github.io/nu
 
 Specify the desired automations that are triggered when all conditions are met, read more [here](/automation-actions).
 
-Each automation includes conditions in an `if` section and actions in a `run` section. 
+Each automation includes conditions in an `if` section and actions in a `run` section.
 
 **Conditions:** Multiple conditions can be listed for a single automation, with AND relationship between the conditions, hence all listed conditions must pass to invoke the actions. The conditions are evaluated on new Pull Requests or changes to the Pull Request.
 
@@ -106,7 +106,7 @@ The following sections are used in `.cm` file to describe the desired automation
 The first section in a `gitstream.cm` file is the `manifest`.
 
 ```yaml+jinja
-manifest: 
+manifest:
   version: 1.0
 ```
 
@@ -132,19 +132,19 @@ The `config` section is optional in the `.cm` file and is used to specify config
 | `config.user_mapping`        | [String: String] | `[]` | per `.cm` file | Key value list of Git user detailes and Git provider account names  |
 
 
-##### `config.admin.users` 
+##### `config.admin.users`
 
 When specified in `gitstream.cm` the `config.admin.users` allows adding admin rights, when a PR changes the `*.cm` files only, if the user is listed in `config.admin.users` the PR will be then approved by gitStream. For example, setting `popeye` as admin:
 
 ```yaml title="example"
 config:
   admin:
-    users: ['popeye'] 
+    users: ['popeye']
 ```
 
 This configuration is valid only when used in `.cm/gitstream.cm`, when defined in other `.cm` files this configuration is ignored.
 
-##### `config.ignore_files` 
+##### `config.ignore_files`
 
 The `config.ignore_files` supports glob pattern matching that contains list of files to ignore, for example:
 
@@ -157,7 +157,7 @@ config:
     - 'ui/src/**/*Model.d.ts'
 ```
 
-##### `config.ignore_repositories` 
+##### `config.ignore_repositories`
 
 The `config.ignore_repositories` contains list of repositories to ignore, for example:
 
@@ -170,7 +170,7 @@ config:
 
 For the listed repositories, the automation defined in the CM file shall not apply.
 
-##### `config.user_mapping` 
+##### `config.user_mapping`
 
 Accepts list of key value strings.
 
@@ -191,21 +191,21 @@ On the other hand, when using `explainRankByGitBlame` with `add-comment@v1` it s
 ```yaml+jinja
 - action: add-reviewers@v1
   args: # (1)
-    reviewers: {{ repo | rankByGitBlame(gt=25) }} 
+    reviewers: {{ repo | rankByGitBlame(gt=25) }}
 
-- action: add-comment@v1 
+- action: add-comment@v1
   args: # (2)
     comment: |
-      {{ repo | explainRankByGitBlame(gt=25) }} 
+      {{ repo | explainRankByGitBlame(gt=25) }}
 ```
 
 1.  `rankByGitBlame` will drop `null` users
 2.  `explainRankByGitBlame` will NOT drop `null` users
 
 
-#### `automations` 
+#### `automations`
 
-The `automations` section defines the automations and their conditions. 
+The `automations` section defines the automations and their conditions.
 
 ```yaml+jinja
 automations:
@@ -227,7 +227,7 @@ Each automation includes its name, and few fields: `if` and `run`.
 | `automations.NAME.if`  | Y | Map | List of conditions with AND relationship |
 | `automations.NAME.run` | Y | Map | Actions to run if all conditions are met, invoked one by one |
 
-The `if` field includes the list of conditions. The conditions are checked when a pull request 
+The `if` field includes the list of conditions. The conditions are checked when a pull request
 is opened or changed, if all the conditions pass, the automation is executed.
 
 The `run` field includes the automation to execute. It includes the following fields:
@@ -244,7 +244,7 @@ gitStream supported actions, see [actions](/automation-actions).
 
 ### Reusing checks
 
-You can define an accessory section, e.g. `checks`, that defines common conditions, and reuse.  
+You can define an accessory section, e.g. `checks`, that defines common conditions, and reuse.
 
 ```yaml+jinja
 size:
@@ -261,9 +261,9 @@ automations:
       - action: approve@v1
   mark_small_medium:
     if:
-      # Check that the PR is either small or medium size 
+      # Check that the PR is either small or medium size
       - {{ size.is.small or size.is.medium }}
-      # AND its less than 5 minutes review (estimated) 
+      # AND its less than 5 minutes review (estimated)
       - {{ branch | estimatedReviewTime <= 5 }}
     run:
       - action: add-label@v1

--- a/docs/github-installation.md
+++ b/docs/github-installation.md
@@ -49,12 +49,12 @@ You can set up gitStream for a single repo or your entire GitHub organization. S
         **Create a Continuous Merge Repo**
 
         To begin, create a repository named `cm` in your GitHub organization. The repo can be either public or private; no other repo configurations are required at this time.
-        
+
         **gitStream**
 
         Create a `gitstream.cm` rules file in the root directory of your repository's default branch (usually `master` or `main`). This file will contain a YAML configuration that determines the workflows that run on your organization's repos. You can name it anything you want as long as it ends in `.cm`
 
-        !!! info "Configuration files go in the repo's root directory." 
+        !!! info "Configuration files go in the repo's root directory."
             Unlike the set up instructions for a single repo, your `.cm` files should be placed in the repository's root directory.
         ```yaml+jinja
         --8<-- "docs/downloads/gitstream.cm"
@@ -103,18 +103,18 @@ Here are some additional resources to help you get the most out of gitStream
 ### How do I configure gitStream to block merges? <a name="github-merge-block"></a>
 You can configure Github to require gitStream checks to pass before PRs can be merged using [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches).
 
-!!! info "Run a gitStream check before continuing" 
+!!! info "Run a gitStream check before continuing"
     You need to run a check using your gitStream configuration at least once before it can be set as a required check. Make sure to open at least 1 PR before doing this setting.
 
 Here are the steps to configure gitStream in your repo's branch protection rules.
 
 1. Go to repo `settings`
-2. On the left panel select `Code and automation` > `Branches` 
-3. Set `Branch protection rules` for your desired branch 
+2. On the left panel select `Code and automation` > `Branches`
+3. Set `Branch protection rules` for your desired branch
 4. Enable `Require status checks to pass before merging`
 5. Search for `status checks in the last week for this repository`
 6. Select `gitStream.cm` as required check
 
 ![Branch protection rules](/screenshots/branch_protection_in_github.png)
-  
+
 ![Required checks](/screenshots/required_checks_in_github.png)

--- a/docs/gitlab-installation.md
+++ b/docs/gitlab-installation.md
@@ -1,19 +1,21 @@
-# GitLab installation 
+# GitLab installation
 
 Prerequisites:
 
 1. GitLab cloud
 2. GitLab runner v15 or higher
 
-!!! tip 
+!!! tip
 
-    Automation rules by gitStream are executed on behalf of the user account used to install it. We recommend to continue with a new dedicated account (e.g. `gitstream-cm`) in GitLab and install gitStream app with it. The service account has to have `Maintainer`  role.
+```text
+Automation rules by gitStream are executed on behalf of the user account used to install it. We recommend to continue with a new dedicated account (e.g. `gitstream-cm`) in GitLab and install gitStream app with it. The service account has to have `Maintainer`  role.
+```
 
 ## Installation
 
 **Step 1 of 4:** Create a `.cm/gitstream.cm` rules file in the work repository default branch (usually `master` or `main`) with the following contents:
 
-```yaml+jinja
+```yaml
 --8<-- "docs/downloads/gitstream.cm"
 ```
 
@@ -21,7 +23,7 @@ Prerequisites:
 
 **Step 3 of 4:** Create a `./.gitlab-ci.yml` CI/CD file in the `cm` repository default branch (usually `master` or `main`) with the following contents:
 
-```yaml+jinja
+```yaml
 --8<-- "docs/downloads/gitlab-ci.yml"
 ```
 
@@ -38,14 +40,14 @@ Eventually, the following files should exist in each of the selected repos:
 
 In the `cm` repository:
 
-```
+```text
 .
 ├─ .gitlab-ci.yml
 ```
 
 In your target repository:
 
-```
+```text
 .
 ├─ .cm/
 │  └─ gitstream.cm
@@ -58,11 +60,13 @@ In your target repository:
 
 ## Permissions
 
-!!! attention 
+!!! attention
 
-	When renaming or adding new repositories, you must re-authenticate gitStream in [GitLab](https://api.gitstream.cm/auth/grant/gitlab)
+```text
+When renaming or adding new repositories, you must re-authenticate gitStream in [GitLab](https://api.gitstream.cm/auth/grant/gitlab)
+```
 
-The required permissions are: 
+The required permissions are:
 
 | Permissions           | Reason |
 |----------------------|-------------------------------------------------------|

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -6,10 +6,10 @@ Every time a dev opens a new Pull Request or changes a Pull Request, gitStream i
 
 In general, the next steps are common practice of changing code in repo:
 
-1. Create a feature branch 
-2. Commit changes  
-3. Push branch to remote repo 
-4. Open Pull Request 
+1. Create a feature branch
+2. Commit changes
+3. Push branch to remote repo
+4. Open Pull Request
 
 
 ```mermaid
@@ -28,16 +28,16 @@ gitGraph
 When gitStream installed and configured, whenever a new PR is opened, several actors are running:
 
 1. Git provider API
-2. gitStream **service** which you have installed from the marketplace 
-3. gitStream **CI/CD** script that is placed per the Git provider requirements 
+2. gitStream **service** which you have installed from the marketplace
+3. gitStream **CI/CD** script that is placed per the Git provider requirements
 4. gitStream **agent** that is executed by the CI/CD script
 
 Once a new PR is opened (or changed) the following process occurs:
 
-1. gitStream gets event for the new PR 
+1. gitStream gets event for the new PR
 2. gitStream calls the **CI/CD** script
-3. The installed action pulls and runs gitStream action `linear-b/gitstream-github-action@v1`. 
-4. This action runs locally in the repo and relies on 
+3. The installed action pulls and runs gitStream action `linear-b/gitstream-github-action@v1`.
+4. This action runs locally in the repo and relies on
 5. The current branch is used to check which automations are valid from `.cm/gitstream.cm`
 6. The action calls to gitStream app with metadata
 7. gitStream app returns results
@@ -53,7 +53,7 @@ The following diagram describes the flow:
 sequenceDiagram
   autonumber
   Git provider API->>gitStream app: new PR
-  gitStream app->>gitStream CI/CD script: run 
+  gitStream app->>gitStream CI/CD script: run
   activate gitStream CI/CD script
   gitStream CI/CD script->>gitStream CI/CD script: pull agent action
   gitStream CI/CD script->>gitStream in repo agent: run
@@ -106,9 +106,9 @@ gitGraph
 
 ## Automation results
 
-Eventually, the gitStream app shows the following statuses:  
+Eventually, the gitStream app shows the following statuses:
 
-![Success](/assets/github_pr_check_pass.png) Success - when the applicable automation finished and PR is good to go 
+![Success](/assets/github_pr_check_pass.png) Success - when the applicable automation finished and PR is good to go
 
 ![Neutral](/assets/github_pr_check_neutral.png) Neutral - when there aren't any applicable automations for the PR
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **gitStream automates your reviews, so you can focus human effort on what matters most.** Not all Pull Requests are the same. Some reviews can be automated, like changes using a specific API (deprecated, sensitive), changes that are non-functional, like docs or tests, or even reformatting code. Automate these reviews to reduce context switches by assigning specific people to review, approve, or even merge simple changes that passed all checks, and more.
 
-#### Quick Start
+## Quick Start
 
 Take these three steps to see how gitStream works; later on you can learn about the .cm file, see some automation examples and learn how to create and edit your automation.
 
@@ -10,10 +10,10 @@ Take these three steps to see how gitStream works; later on you can learn about 
 
 	1. Install gitStream for free in [GitHub](https://github.com/apps/gitstream-cm/installations/new)
 	2. Configure your repository using the [instructions for GitHub](github-installation.md)
-	
+
 	That's it! Now sit back and watch gitStream automation rules on your next PR (You don’t have to merge it)
 
-	!!! note 
+	!!! note
 
 		When installing for GitHub, gitStream can be installed for one repo, specific repos, or all repos in your organization. We recommend installing for **all**, as it will also cover new repos you add in the future. You can change this setting at any time later.
 
@@ -29,21 +29,21 @@ Take these three steps to see how gitStream works; later on you can learn about 
 
 ## Features
 
-**📐  Building Custom Rules**
+### 📐  Building Custom Rules
 
-- PR Complexity 
+- PR Complexity
 - Multiple sources
-- Code change variables  
+- Code change variables
 - Branch details & history
 
 
-**🤖  gitStream engine**
+### 🤖  gitStream engine
 
 - Auto-merge PRs
 - Custom PR labels
-- Require specific reviewers 
+- Require specific reviewers
 - Automated change requests
-- Increase quality requirements 
+- Increase quality requirements
 - Based on Jinja2 template engine
 
 ## Continuous Merge
@@ -56,4 +56,3 @@ Take these three steps to see how gitStream works; later on you can learn about 
 
 ![Continuous Merge](/assets/ContinuousMerge3l.png#only-light)
 ![Continuous Merge](/assets/ContinuousMerge3d.png#only-dark)
-


### PR DESCRIPTION
depends on #84

I pulled the docs to fix spelling and got distracted by inconsistent formatting in markdown. I recommend setting up some blocking pipeline with markdownlint. My personal choice is trunk.io (free) but there are plenty of alternatives.

or at least setting up your editors to trim trailing whitespace. VSCode settings: 

```json
  "files.trimTrailingWhitespace": true,
  "files.insertFinalNewline": true,
  "files.trimFinalNewlines": true,
```

- spelling fixes
- some formatting changes
