### PR TITLE
Update automation rules

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -25,7 +25,7 @@ automations:
         args:
           reviewers: {{ maintainers }}
   # Mark changes to automation rule examples as they need to be tested and working
-  notify_maintainers:
+  mark_examples:
     if:
       - {{ files | match(regex=r/\.(cm)$/) | some }}
     run:

--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -8,13 +8,33 @@ config:
     users: [vim-zz]
 
 automations:
-  estimated_time_to_review:
+  # Approve docs changes by maintainers, so they are not blocked.
+  # Merging is still manaul 
+  approve_maintainers_docs:
     if:
       - {{ files | match(regex=r/\.(md|txt|png|svg|webp)$/) | every }}
       - {{ pr.author | match(list=maintainers) }}
     run:
       - action: approve@v1
-      - action: merge@v1
+  # Notify maintainers on new PRs
+  notify_maintainers:
+    if:
+      - true
+    run:
+      - action: add-reviewers@v1
+        args:
+          reviewers: {{ maintainers }}
+  # Mark changes to automation rule examples as they need to be tested and working
+  notify_maintainers:
+    if:
+      - {{ files | match(regex=r/\.(cm)$/) | some }}
+    run:
+      - action: add-label@v1
+        args:
+          label: 'examples-code'
+          color: '#FF9800'
+
 
 maintainers:
   - 'vim-zz'
+  - 'BenLloydPearson'


### PR DESCRIPTION
1. Approve docs changes by maintainers, so they are not blocked.
2. Notify maintainers on new PRs
3. Mark changes to automation rule examples as they need to be tested and working