### PR TITLE
describe admin rules

### DIFF
--- a/docs/cm-file.md
+++ b/docs/cm-file.md
@@ -120,6 +120,8 @@ config:
 
 This configuration is valid only when used in `.cm/gitstream.cm`, when defined in other `.cm` files this configuration is ignored.
 
+When added in the `cm` repository (i.e. at the organizational level), the specified users obtain administrative privileges to CM changes across every repository in the organization. Consequently, for every pull request that modifies a CM file in any of the repositories, the `config.admin.users` parameters are drawn from both the pull request repository and the `cm` repository.
+
 ##### `config.ignore_files`
 
 The `config.ignore_files` supports glob pattern matching that contains list of files to ignore, for example:

--- a/docs/cm-file.md
+++ b/docs/cm-file.md
@@ -120,7 +120,7 @@ config:
 
 This configuration is valid only when used in `.cm/gitstream.cm`, when defined in other `.cm` files this configuration is ignored.
 
-When added in the `cm` repository (i.e. at the organizational level), the specified users obtain administrative privileges to CM changes across every repository in the organization. Consequently, for every pull request that modifies a CM file in any of the repositories, the `config.admin.users` parameters are drawn from both the pull request repository and the `cm` repository.
+When you add a user to `config.admin.users` in your organization's `cm` repository, they are granted administrative privileges to CM changes across **every repository** in the organization. gitStream evaluates CM rules in the individual repository **and** your organization's `cm` repository to determine admin users.
 
 ##### `config.ignore_files`
 


### PR DESCRIPTION
New feature, org level admins:

> When added in the `cm` repository (i.e. at the organizational level), the specified users obtain administrative privileges to CM changes across every repository in the organization. Consequently, for every pull request that modifies a CM file in any of the repositories, the `config.admin.users` parameters are drawn from both the pull request repository and the `cm` repository.
