### PR TITLE
Gitlab org level setup

### DIFF
--- a/docs/downloads/gitlab-ci.yml
+++ b/docs/downloads/gitlab-ci.yml
@@ -17,8 +17,9 @@ gitstream-job:
       - $GITSTREAM_BLOCK_MERGE
   script:
     - apk update && apk add git && apk add docker
-    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}${repoUrl} gitstream/
-    - cd gitstream && git fetch --all && git checkout $base_ref && git pull && ls && git checkout $head_ref && git pull && ls
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}${repoUrl} gitstream/repo
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}${cmUrl} gitstream/cm
+    - cd gitstream && cd repo && git fetch --all && git checkout $base_ref && git pull && ls && git checkout $head_ref && git pull && ls
     - docker pull gitstream/rules-engine:latest
     - |
       docker run -v $CI_PROJECT_DIR/gitstream:/code \
@@ -26,4 +27,5 @@ gitstream-job:
       -e BASE_REF=$base_ref \
       -e CLIENT_PAYLOAD="$client_payload" \
       -e RULES_RESOLVER_URL=$resolver_url \
-      -e RULES_RESOLVER_TOKEN=$resolver_token gitstream/rules-engine
+      -e RULES_RESOLVER_TOKEN=$resolver_token \
+      -e DEBUG_MODE=true  gitstream/rules-engine:latest

--- a/docs/gitlab-installation.md
+++ b/docs/gitlab-installation.md
@@ -1,4 +1,4 @@
-# GitLab installation
+# How to Setup gitStream with GitLab
 
 Prerequisites:
 
@@ -7,56 +7,108 @@ Prerequisites:
 
 !!! tip
 
-	Automation rules by gitStream are executed on behalf of the user account used to install it. We recommend to continue with a new dedicated account (e.g. `gitstream-cm`) in GitLab and install gitStream app with it. The service account has to have `Maintainer`  role.
+	Automation rules by gitStream are executed on behalf of the user account used to install it. We recommend to continue with a new dedicated account (e.g. `gitstream-cm`) in GitLab and install gitStream app with it. The service account has to have `Maintainer` role.
 
-## Installation
+## Setup
 
-**Step 1 of 4:** Create a `.cm/gitstream.cm` rules file in the work repository default branch (usually `master` or `main`) with the following contents:
+You can set up gitStream for a single repo or your entire GitLab organization. Select the tab below for the instructions you want.
+=== "Single Repo"
+    **Single Repo Setup**
 
-```yaml
---8<-- "docs/downloads/gitstream.cm"
-```
+    You must implement two main components for gitStream to function for a single GitLab repo. The first is a configuration file that defines the workflow automations to execute for the repo. The second is a GitLab actions configuration file that triggers gitStream when PRs are created or updated which is hosted in a special `cm` repo.
 
-**Step 2 of 4:** Create a new `cm` project (repository) in your GitLab group. It should be created in the same group or a parent group of the target repositories.
+    !!! Warning "Prerequisite: Create a cm repo and enable gitStream."
+        Create a `cm` project (repository) in your GitLab group. It should be created in the same group or a parent group of the target repositories
 
-**Step 3 of 4:** Create a `./.gitlab-ci.yml` CI/CD file in the `cm` repository default branch (usually `master` or `main`) with the following contents:
+    !!! example "Required Configurations"
+        **gitStream**
 
-```yaml
---8<-- "docs/downloads/gitlab-ci.yml"
-```
+        Create a `.cm/gitstream.cm` rules file in your repository's default branch (usually `master` or `main`). This file will contain a YAML configuration that determines the workflows that run on the repo, and you can name it anything you want as long as it ends in `.cm`
 
-**Step 4 of 4:** Install gitStream app for [GitLab](https://api.gitstream.cm/auth/grant/gitlab){ .md-button }.
+        Here is an example of a gitStream configuration file you can use to setup some basic workflow automations.
+
+        ```yaml+jinja
+        --8<-- "docs/downloads/gitstream.cm"
+        ```
+
+        **GitLab CI**
+
+        Once your gitStream configuration file is setup, you need a GitLab CI configuration file to trigger gitStream automations. Create a new `cm` project (repository) in your GitLab group. It should be created in the same group or a parent group of the target repositories. Create a `.gitlab-ci.yml` file in your new `cm` repository's default branch (usually `master` or `main`) and add the following configuration:
+
+        ```yaml+jinja
+        --8<-- "docs/downloads/gitlab-ci.yml"
+        ```
+
+        !!! Success
+            When finished, you should have the following file structure in your `cm` repo.
+
+            ```text
+            .
+            ├─ .gitlab-ci.yml
+            ```
+
+            And in your target repository:
+
+            ```text
+            .
+            ├─ .cm/
+            │  └─ gitstream.cm
+            ```
+
+=== "GitLab Group"
+    **GitLab Group Setup**
+
+    Organization rules are ideal when you want to enforce consistent rules across every repo in your organization. You can define them by creating a special repository named `cm` in your GitLab organization top group where you can add automation files that will apply to **all** repositories within that organization.
+
+    !!! Warning "Prerequisite: Create a cm repo and enable gitStream."
+        Create a `cm` project (repository) in your GitLab group. It should be created in the same group or a parent group of the target repositories
+
+    !!! example "Required Configurations"
+        **gitStream**
+
+        Create a `gitstream.cm` rules file in the root directory of your `cm` repository's default branch (usually `master` or `main`). This file will contain a YAML configuration that determines the workflows that run on your organization's repos. You can name it anything you want as long as it ends in `.cm`
+
+        !!! info "Configuration files go in the repo's root directory."
+            Unlike the set up instructions for a single repo, your `.cm` files should be placed in the repository's root directory.
+        ```yaml+jinja
+        --8<-- "docs/downloads/gitstream.cm"
+        ```
+        **GitLab CI**
+
+        Once your gitStream configuration file is setup, you need a GitLab CI configuration file to trigger gitStream automations. Create a `.gitlab-ci.yml` file in your new `cm` repository's default branch (usually `master` or `main`) and add the following configuration:
+
+        ```yaml+jinja
+        --8<-- "docs/downloads/gitlab-ci.yml"
+        ```
+
+        !!! Success
+            When finished, you should have the following file structure in your `cm` repo.
+
+            ```text
+            .
+            ├─ .gitlab-ci.yml
+            ├─ gitstream.cm
+            ```
+
+!!! Warning "Install gitStream"
+
+    Before you can complete the gitStream setup process, you need to install the gitStream app to your [GitLab organization](https://api.gitstream.cm/auth/grant/gitlab){ .md-button }.
+
+!!! info "gitStream will now do these two things."
+        When a PR is created or changed, apply or update a label that provides an estimated time to review.
+        ![Estimated Review Time label](screenshots/etr_label_example.png)
+        ![Estimated review time](screenshots/slack-estimated-review-time-example-1-min.png)
+
+        When a new PR is created, comment with a list of code experts.
+        ![Suggested reviewers](screenshots/gitHub-codeexperts-expanded.png)
+## Next Step
+!!! tip "How gitStream Works"
+        Read our guide: [How gitStream Works](/how-it-works/) to get an overview of the gitStream syntax and automation lifecycle.
+
+## Additional Resources
 
 
-## Next steps
-
-To learn how to add your first rule, jump to the [Quick Start](quick-start.md) page.
-
-## Configuration files
-
-Eventually, the following files should exist in each of the selected repos:
-
-In the `cm` repository:
-
-```text
-.
-├─ .gitlab-ci.yml
-```
-
-In your target repository:
-
-```text
-.
-├─ .cm/
-│  └─ gitstream.cm
-```
-
-| File and path         | Reason |
-|-----------------------|----------------------------------------|
-| `.cm/*.cm`    | Under the repo's `.cm` directory, any file that ends with `.cm` will be used by gitStream to specify automation rules, you can edit these files |
-| `.gitlab-ci.yml` | Used by gitStream to execute automation rules in your GitLab repo so source code doesn't get to outside services |
-
-## Permissions
+### Required GitLab Permissions
 
 !!! attention
 
@@ -70,9 +122,12 @@ The required permissions are:
 | Read repository | To read and check rules over the code changes on monitored repositories |
 | Read user profile | Used to identify users |
 
-## gitStream actions
+### No support for gitStream to Block Merges
+gitStream actions that blocks MR merge are not support at the moment.
 
-Automation rules by gitStream are executed on behalf of the user account used to install it. We recommend using a new dedicated account in GitLab for installing gitStream, e.g. `gitstream`
+### gitStream service account
+
+Automation rules by gitStream are executed on behalf of the user account used to install it. We recommend using a new dedicated account in GitLab for installing gitStream, e.g. `gitstream-cm`
 
 ## Uninstalling gitStream
 


### PR DESCRIPTION
1. updated `gitlab-ci.yml`
2. clear instrcutions to set up a new `cm` repo
3. Actually, global rules are supported by default in GitLab, all you have to do is adding CM file in the `cm` repo to make it apply to all repos