### PR TITLE
Update gitstream.cm

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -55,7 +55,7 @@ automations:
 
 has:
   screenshot_link: {{ pr.description | includes(regex=r/!\[.*\]\(.*(jpg|svg|png|gif|psd).*\)/) }}
-  image_uploaded: {{ pr.description | includes(regex=r/<img.*src.*(jpg|svg|png|gif|psd).*>/) }}
+  image_uploaded: {{ pr.description | includes(regex=r/<img.*src.*>/) }}
 
 
 maintainers:


### PR DESCRIPTION
GitHub changed the drag and drop assests links, and now they dont include the image extension. For example: `<img width="1238" alt="Screenshot 2023-05-12 at 8 33 26" src="https://github.com/linear-b/gitstream/assets/50141/4e72d779-1590-4acb-918f-230a43361888">`