### PR TITLE
point to the CM syntax definitions for ST4

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,7 +38,7 @@ Add the following line to the top of the `.cm` file (the default has it already)
 Get a plug-in that enable modelines, popular ones are:
 
 - VS Code: [Modelines](https://marketplace.visualstudio.com/items?itemName=chrislajoie.vscode-modelines)
-- Sublime Text: [Emacs-like Sublime Modeline](https://github.com/kvs/STEmacsModelines)
+- Sublime Text: [CM syntax for ST4](https://packagecontrol.io/packages/Continuous%20Merge) or [Emacs-like Sublime Modeline](https://github.com/kvs/STEmacsModelines)
 - Vim [Modeline magic](https://vim.fandom.com/wiki/Modeline_magic)
 
 ## I have an issue I can seem to solve, what should I do?


### PR DESCRIPTION
in the FAQ:

<img width="680" alt="Screenshot 2023-07-06 at 11 02 30" src="https://github.com/linear-b/gitstream/assets/50141/a921bf1b-412c-4cd0-a8ca-5872371a93bb">


in package control:

<img width="1104" alt="Screenshot 2023-07-06 at 11 02 35" src="https://github.com/linear-b/gitstream/assets/50141/d83d879a-516e-4092-afb1-1b939f7db20f">
