### PR TITLE
meta descriptions galore

### DIFF
--- a/docs/automations/additional-review-for-large-pr/README.md
+++ b/docs/automations/additional-review-for-large-pr/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Additional Review for Large PRs
+description: Require extra code reviews for large PRs.
+---
 # Additional Review for Large PRs
 Require 2 reviewers for PRs that have more than 10 changed files in the src directory and the estimated time to review is 30 or more minutes.
 

--- a/docs/automations/approve-javascript-formatting-change/README.md
+++ b/docs/automations/approve-javascript-formatting-change/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve JavaScript Formatting Changes
+description: Automatically approve PRs that only change JavaScript formatting.
+---
 # Approve JavaScript Formatting Changes
 Approve PRs that only contain formatting changes to JavaScript or TypeScript files. 
 

--- a/docs/automations/approve-javascript-log-output/README.md
+++ b/docs/automations/approve-javascript-log-output/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve JavaScript Log Output Changes
+description: Automatically approve PRs that only change JavaScript log output.
+---
 # Approve JavaScript Log Output Changes
 
 Approve changes to JavaScript files that only affect lines of code that invoke the console.log() method.

--- a/docs/automations/approve-python-formatting-change/README.md
+++ b/docs/automations/approve-python-formatting-change/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve Python Formatting Changes
+description: Automatically approve PRs that only contain Python formatting changes.
+---
 # Approve Python Formatting Changes
 Approve PRs that only contain formatting changes to Python files. 
 

--- a/docs/automations/approve-python-log-output/README.md
+++ b/docs/automations/approve-python-log-output/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve Python Log Output Changes
+description: Automatically approve PRs that only affect Python log output.
+---
 # Approve Python Log Output Changes
 
 Approve changes to Python files that only affect lines of code that invoke a specified logging object.

--- a/docs/automations/approve-safe-changes/README.md
+++ b/docs/automations/approve-safe-changes/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve Safe Changes
+description: Automatically approve PRs for documentation, formatting, and tests.
+---
 # Approve Safe Changes
 
 If the PR content only contains one or more of documentation, formatting changes, or tests, automatically approve the PR and apply a safe change label.

--- a/docs/automations/approve-team-by-directory/README.md
+++ b/docs/automations/approve-team-by-directory/README.md
@@ -1,4 +1,7 @@
-
+---
+title: gitStream Automation - Approve Expert Team
+description: Automatically approve PRs from trusted teams.
+---
 # Approve Expert Team
 Approve PRs to a specified directory from a specific team. 
 

--- a/docs/automations/approve-tests/README.md
+++ b/docs/automations/approve-tests/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve test changes
+description: Automatically approve changes that only contains updates to tests.
+---
 # Approve test changes
 
 Label and approve PRs that only include tests, and post an explanation comment.

--- a/docs/automations/approve-tiny-changes/README.md
+++ b/docs/automations/approve-tiny-changes/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve Tiny Changes
+description: Automatically approve small PRs.
+---
 # Approve Tiny Changes
 
 Approve single-line changes to a single file.

--- a/docs/automations/assign-code-experts/README.md
+++ b/docs/automations/assign-code-experts/README.md
@@ -1,4 +1,7 @@
-
+---
+title: gitStream Automation - Assign Code Experts
+description: Automatically assign PR reviewers based on code expertise.
+---
 # Assign Code Experts
 
 When someone applies a `suggest-reviewers` label to a PR, use codeExperts to assign recommended reviewers and post a comment with the `explainCodeExperts` automation action.

--- a/docs/automations/assign-reviewers-by-directory/README.md
+++ b/docs/automations/assign-reviewers-by-directory/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Assign Reviewers by Directory
+description: Automatically assign reviewers based on a watch list of files and directories.
+---
 # Assign Reviewers by Directory
 
 Automatically assign code reviewers based on directory structure. Optionally, you can substitue `require-reviewers` for `add-reviewers` to make review from the specified teams and individuals mandatory.

--- a/docs/automations/assign-team-members-as-reviewers/README.md
+++ b/docs/automations/assign-team-members-as-reviewers/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Assign team members as reviewers
+description: Automatically assign teammates to review PRs.
+---
 # Assign team members as reviewers
 
 Assign PR reviewer based on the owner team membership.

--- a/docs/automations/automation-template.md
+++ b/docs/automations/automation-template.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Automation Name
+description: 
+---
 # Automation Name
 <!-- 
 How to publish a new automation:
@@ -6,7 +10,8 @@ How to publish a new automation:
 3. Place the related CM file and example image in the same directory and give the files the same name as the automation.
 4. Change all instances of "Automation Name" to match the name of your automation
 5. Add a short description and image (update the image link too), and fill in the list of conditions and automation actions.
-6. Delete this comment and publish the automation!
+6. Fill in the meta description at the top.
+7. Delete this comment and publish the automation!
 !-->
 Short description
 

--- a/docs/automations/change-deprecated-components/README.md
+++ b/docs/automations/change-deprecated-components/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Change Deprecated Components
+description: Automatically detect the use of deprecated components and services in PRs.
+---
 # Change Deprecated Components
 
 Request changes when a PR includes one or more deprecated components.

--- a/docs/automations/change-missing-lambda-field/README.md
+++ b/docs/automations/change-missing-lambda-field/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Change Missing Lambda Field
+description: Detect missing Lambda fields that are required in all PRs.
+---
 # Change Missing Lambda Field
 
 If a PR creates a new Lambda function, but lacks a description field, gitStream will request changes and post a comment that explains why. 

--- a/docs/automations/close-wrong-team-by-directory/README.md
+++ b/docs/automations/close-wrong-team-by-directory/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Close Wrong Team by Directory
+description: Automatically close PRs to protected portions of your code.
+---
 # Close Wrong Team by Directory
 
 Close PRs to a specified directory if the PR author is not on an approved team.

--- a/docs/automations/integrations/dependabot/approve-dependabot/README.md
+++ b/docs/automations/integrations/dependabot/approve-dependabot/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve and Merge Dependabot Changes
+description: Automatically approve and merge Dependabot PRs.
+---
 # Approve and Merge Dependabot Changes
 
 Approve PRs from Dependabot

--- a/docs/automations/integrations/javadoc/review-javadoc-input-parameters/README.md
+++ b/docs/automations/integrations/javadoc/review-javadoc-input-parameters/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Java Input Parameters for Javadoc Changes
+description: Notify PR authors to ensure proper Javadoc coverage. 
+---
 # Review Java Input Parameters for Javadoc Changes
 
 If a PR modifies the input parameters for a Java method, but not the associated Javadocs, notify reviewers to check for Javadoc updates.

--- a/docs/automations/integrations/javadoc/review-javadoc-large-change/README.md
+++ b/docs/automations/integrations/javadoc/review-javadoc-large-change/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Javadoc for Large Changes
+description: Automatically flag large PRs that may require Javadoc updates.
+---
 # Review Javadoc for Large Changes
 
 Require more extensive reviews for large Java changes that lack Javadoc updates.

--- a/docs/automations/integrations/javadoc/review-javadoc/README.md
+++ b/docs/automations/integrations/javadoc/review-javadoc/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Javadoc Changes
+description: Automatically approve PRs that only contain Javadoc changes.
+---
 # Review Javadoc Changes
 
 Unblock PRs that only change Javadoc content.

--- a/docs/automations/integrations/javadoc/review-new-class-javadoc/README.md
+++ b/docs/automations/integrations/javadoc/review-new-class-javadoc/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Enforce Javadoc Requirements for New Classes
+description: Automatically request changes for PRs that fail to meet Javadoc requirements.
+---
 # Enforce Javadoc Requirements for New Classes
 
 Automatically request changes when someone creates a new Java class that lacks Javadoc content.

--- a/docs/automations/integrations/jira/label-missing-jira-info/README.md
+++ b/docs/automations/integrations/jira/label-missing-jira-info/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Label Missing Jira Info
+description: Automatically flag PRs that are missing required references to Jira issues.
+---
 # Label Missing Jira Info
 Label PRs that don't reference a Jira ticket in the title or description. This uses regex to detect Jira ticket formats in the title (e.g. ABC-1234), and URLs to Jira tickets in the description.
 

--- a/docs/automations/integrations/jit/label-jit-alerts/README.md
+++ b/docs/automations/integrations/jit/label-jit-alerts/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Label Jit Alerts
+description: Automatically label PRs with Jit findings.
+---
 # Label Jit Alerts
 Label the number of high, medium, and low risk vulnerabilities Jit reports for PRs.
 

--- a/docs/automations/integrations/jit/review-jit-alerts/README.md
+++ b/docs/automations/integrations/jit/review-jit-alerts/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Jit Security Alerts
+description: Automatically assign PR reviewers for Jit security alerts.
+---
 # Review Jit Security Alerts
 Manage review assignment for high and medium risk Jit security alerts.
 

--- a/docs/automations/integrations/jit/review-jit-ignore-accept/README.md
+++ b/docs/automations/integrations/jit/review-jit-ignore-accept/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Jit Ignore and Accept
+description: Automatically notify your security team when someone ignores Jit vulnerabilities.
+---
 # Review Jit Ignore and Accept
 Notify your Security team when someone ignores a Jit vulnerability report and accepts the risk.
 

--- a/docs/automations/integrations/jit/review-jit-secret/README.md
+++ b/docs/automations/integrations/jit/review-jit-secret/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Jit Secret Detection
+description: Automatically block PRs that contain secrets.
+---
 # Review Jit Secret Detection
 Close PRs where Jit detects a secret and post a comment explaining steps to remedy the situation.
 

--- a/docs/automations/integrations/jsdoc/review-jsdoc-input/README.md
+++ b/docs/automations/integrations/jsdoc/review-jsdoc-input/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review JSDoc Input Parameters
+description: Automatically flag PRs that may require JSDoc updates.
+---
 # Review JSDoc Input Parameters
 
 Warn PR authors when they change JavaScript function or constructor input parameters without updating JSDoc content.

--- a/docs/automations/integrations/jsdoc/review-jsdoc-large/README.md
+++ b/docs/automations/integrations/jsdoc/review-jsdoc-large/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review JSDoc for Large Changes
+description: Automatically flag large PRs that may require JSDoc updates.
+---
 # Review JSDoc for Large Changes
 
 Require more extensive reviews for large JavaScript changes that lack JSDoc updates.

--- a/docs/automations/integrations/jsdoc/review-jsdoc-new-class/README.md
+++ b/docs/automations/integrations/jsdoc/review-jsdoc-new-class/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Enforce JSDoc for New JavaScript Classes
+description: Enforce JSDoc requirements for PRs.
+---
 # Enforce JSDoc for New JavaScript Classes
 
 Require JSDoc for all new JavaScript classes.

--- a/docs/automations/integrations/jsdoc/review-jsdoc/README.md
+++ b/docs/automations/integrations/jsdoc/review-jsdoc/README.md
@@ -1,6 +1,10 @@
+---
+title: gitStream Automation - Review JSDoc Changes
+description: Automatically approve PRs for JSDoc changes.
+---
 # Review JSDoc Changes
 
-Assign reviewers for PRs that only contain changes to JSDoc.
+Approve PRs that only contain changes to JSDoc and assign optional reviewers.
 
 <div class="automationImage" markdown="1">
 ![Review JSDoc](/automations/integrations/jsdoc/review-jsdoc/review-jsdoc.png)

--- a/docs/automations/integrations/sonar/approve-sonar-clean-code/README.md
+++ b/docs/automations/integrations/sonar/approve-sonar-clean-code/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve Sonar Clean Code
+description: Automatically approve PRs that pass SonarCloud's quality gate.
+---
 # Approve Sonar Clean Code
 
 Approve PRs that pass SonarCloud's quality gate.

--- a/docs/automations/integrations/sonar/label-sonar/README.md
+++ b/docs/automations/integrations/sonar/label-sonar/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Label SonarCloud Quality Reports
+description: Automatically label PRs with SonarCloud insights.
+---
 # Label SonarCloud Quality Reports
 Label the number of bugs, vulnerabilities, security hotspots, and code smells reported by SonarCloud.
 

--- a/docs/automations/integrations/sonar/review-sonar-alerts/README.md
+++ b/docs/automations/integrations/sonar/review-sonar-alerts/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Sonar Security Alerts
+description: Automatically flag SonarCloud security alerts for additional review.
+---
 # Review Sonar Security Alerts
 
 Require additional reviews for Sonar security alerts. gitStream will remove this requirement if the alerts are resolved.

--- a/docs/automations/integrations/sonar/review-sonar-duplications/README.md
+++ b/docs/automations/integrations/sonar/review-sonar-duplications/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Sonar Duplications
+description: Automatically request changes when SonarCloud detects duplicated code.
+---
 # Review Sonar Duplications
 
 Request changes when Sonar reports an excessive level of duplicated code.

--- a/docs/automations/integrations/swimm/approve-swimm/README.md
+++ b/docs/automations/integrations/swimm/approve-swimm/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Approve Swimm Changes
+description: Automatically approve PRs that only change Swimm documentation.
+---
 # Approve Swimm Changes
 Approve changes that only affect [Swimm](https://swimm.io) documentation.
 

--- a/docs/automations/label-deleted-files/README.md
+++ b/docs/automations/label-deleted-files/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Label Deleted Files
+description: Label PRs that delete files.
+---
 # Label Deleted Files
 
 Label PRs that delete files.

--- a/docs/automations/label-prs-without-tests/README.md
+++ b/docs/automations/label-prs-without-tests/README.md
@@ -1,4 +1,7 @@
-
+---
+title: gitStream Automation - Label PRs Without Tests
+description: Automatically label PRs that lack required tests.
+---
 # Label PRs Without Tests
 Apply a `missing-tests` label to any PRs that don't update tests. gitStream will remove this label if the contributor adds a test change to the PR.
 

--- a/docs/automations/percent-new-code/README.md
+++ b/docs/automations/percent-new-code/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Calculate the Percentage of New Code
+description: Indicate the amount of new code contained in a PR.
+---
 # Calculate the Percentage of New Code
 Post a comment that indicates what percentage of the PR contains new code.
 

--- a/docs/automations/provide-estimated-time-to-review/README.md
+++ b/docs/automations/provide-estimated-time-to-review/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Provide Estimated Time to Review
+description: Automatically label PRs with an estimated time to review.
+---
 # Provide Estimated Time to Review
 Label all PRs with an estimated number of minutes it would take someone to review. gitStream will automatically update this label whenever a PR changes.
 

--- a/docs/automations/request-screenshot/README.md
+++ b/docs/automations/request-screenshot/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Request Screenshot
+description: Automatically ensure PRs contain screenshots to help illustrate the changes.
+---
 # Request Screenshot
 If the PR lacks an image file, or link to an image in the description, apply a `no-screenshot` label and post a comment to request a screenshot. If the PR author updates the description, gitStream will remove the label.
 

--- a/docs/automations/review-sensitive-files/README.md
+++ b/docs/automations/review-sensitive-files/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Review Sensitive Files
+description: Automatically assign reviewers for PRs that contain changes to high-risk code.
+---
 # Review Sensitive Files
 Compare the changed files to a pre-defined list of files and directories in. If any files match, require a review from the team `my-organization/security`.
 

--- a/docs/automations/standard/explain-code-experts/README.md
+++ b/docs/automations/standard/explain-code-experts/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Explain Code Experts
+description: Automatically summarize the people with the highest code expertise for PRs.
+---
 # Explain Code Experts
 
 Post a comment that uses git blame and history to list the most relevant experts for all PRs. The comment will automatically update as additional commits are added to the PR. 

--- a/docs/automations/standard/review-changelog/README.md
+++ b/docs/automations/standard/review-changelog/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Enforce Changelog Updates
+description: Ensure PRS to specific branches include changelog updates.
+---
 # Enforce Changelog Updates
 
 Request changes if a PR that meets specified criteria lacks an update to the project's changelog.

--- a/docs/automations/standard/share-knowledge/README.md
+++ b/docs/automations/standard/share-knowledge/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Knowledge Share
+description: Automatically distribute PR reviews to increase code expertise.
+---
 # Knowledge Share
 Require the reviewer as a previous contributor with code expertise between set thresholds when PR contains `Share Knowledge` label.
 

--- a/docs/automations/welcome-newcomer/README.md
+++ b/docs/automations/welcome-newcomer/README.md
@@ -1,3 +1,7 @@
+---
+title: gitStream Automation - Welcome Newcomer.
+description: Automatically post messages to first time PR contributors to help them get started.
+---
 # Welcome Newcomer
 
 Post a welcome message when someone makes their first PR to a repo, and provide context to help them know what's next.

--- a/docs/integrations/dependabot.md
+++ b/docs/integrations/dependabot.md
@@ -4,4 +4,5 @@ description: Use gitStream to automatically approve and merge Dependabot PRs.
 ---
 # Integrate gitStream with Dependabot
 
---8<-- "docs/automations/integrations/dependabot/approve-dependabot/README.md"
+## Approve and Merge Dependabot Changes
+--8<-- "docs/automations/integrations/dependabot/approve-dependabot/README.md:6:"

--- a/docs/integrations/javadoc.md
+++ b/docs/integrations/javadoc.md
@@ -11,21 +11,24 @@ Javadoc Examples:
 * [Review Javadoc for Large Changes](#review-javadoc-large-change)
 * [Enforce Javadoc Requirements for New Classes](#review-new-class-javadoc)
 
-
 <a name="review-javadoc"></a>
---8<-- "docs/automations/integrations/javadoc/review-javadoc/README.md"
+## Review Javadoc Changes
+--8<-- "docs/automations/integrations/javadoc/review-javadoc/README.md:6:"
 [Direct link to this example](/automations/integrations/javadoc/review-javadoc/)
 
 <a name="review-javadoc-input-parameters"></a>
---8<-- "docs/automations/integrations/javadoc/review-javadoc-input-parameters/README.md"
+## Review Java Input Parameters for Javadoc Changes
+--8<-- "docs/automations/integrations/javadoc/review-javadoc-input-parameters/README.md:6:"
 [Direct link to this example](/automations/integrations/javadoc/review-javadoc-input-parameters/)
 
 <a name="review-javadoc-large-change"></a>
---8<-- "docs/automations/integrations/javadoc/review-javadoc-large-change/README.md"
+## Review Javadoc for Large Changes
+--8<-- "docs/automations/integrations/javadoc/review-javadoc-large-change/README.md:6:"
 [Direct link to this example](/automations/integrations/javadoc/review-javadoc-large-change/)
 
 <a name="review-new-class-javadoc"></a>
---8<-- "docs/automations/integrations/javadoc/review-new-class-javadoc/README.md"
+## Enforce Javadoc Requirements for New Classes
+--8<-- "docs/automations/integrations/javadoc/review-new-class-javadoc/README.md:6:"
 [Direct link to this example](/automations/integrations/javadoc/review-new-class-javadoc/)
 
 Special thanks to [Boemo W Mmopelwa](https://github.com/xTrilton) for providing these examples.

--- a/docs/integrations/jira.md
+++ b/docs/integrations/jira.md
@@ -3,5 +3,5 @@ title: Integrate gitStream with Jira
 description: Use gitStream to implement workflow automations for Jira.
 ---
 # Integrate gitStream with Jira
-
---8<-- "docs/automations/integrations/jira/label-missing-jira-info/README.md"
+## Label Missing Jira Info
+--8<-- "docs/automations/integrations/jira/label-missing-jira-info/README.md:6:"

--- a/docs/integrations/jit.md
+++ b/docs/integrations/jit.md
@@ -15,17 +15,21 @@ Jit Examples:
 * [Review Jit Ignore and Accept Risk](#review-jit-ignore-accept)
 
 <a name="review-jit-alerts"></a>
---8<-- "docs/automations/integrations/jit/review-jit-alerts/README.md"
+## Review Jit Security Alerts
+--8<-- "docs/automations/integrations/jit/review-jit-alerts/README.md:6:"
 [Direct link to this example](/automations/integrations/jit/review-jit-alerts/)
 
 <a name="review-jit-secret"></a>
---8<-- "docs/automations/integrations/jit/review-jit-secret/README.md"
+## Review Jit Secret Detection
+--8<-- "docs/automations/integrations/jit/review-jit-secret/README.md:6:"
 [Direct link to this example](/automations/integrations/jit/review-jit-secret/)
 
 <a name="label-jit-alerts"></a>
---8<-- "docs/automations/integrations/jit/label-jit-alerts/README.md"
+## Label Jit Alerts
+--8<-- "docs/automations/integrations/jit/label-jit-alerts/README.md:6:"
 [Direct link to this example](/automations/integrations/jit/label-jit-alerts/)
 
 <a name="review-jit-ignore-accept"></a>
---8<-- "docs/automations/integrations/jit/review-jit-ignore-accept/README.md"
+## Review Jit Ignore and Accept
+--8<-- "docs/automations/integrations/jit/review-jit-ignore-accept/README.md:6:"
 [Direct link to this example](/automations/integrations/jit/review-jit-ignore-accept/)

--- a/docs/integrations/jsdoc.md
+++ b/docs/integrations/jsdoc.md
@@ -13,19 +13,23 @@ JSDoc Examples:
 
 
 <a name="review-jsdoc"></a>
---8<-- "docs/automations/integrations/jsdoc/review-jsdoc/README.md"
+## Review JSDoc Changes
+--8<-- "docs/automations/integrations/jsdoc/review-jsdoc/README.md:6:"
 [Direct link to this example](/automations/integrations/jsdoc/review-jsdoc/)
 
 <a name="review-jsdoc-input-parameters"></a>
---8<-- "docs/automations/integrations/jsdoc/review-jsdoc-input/README.md"
+## Review JSDoc Input Parameters
+--8<-- "docs/automations/integrations/jsdoc/review-jsdoc-input/README.md:6:"
 [Direct link to this example](/automations/integrations/jsdoc/review-jsdoc-input/)
 
 <a name="review-jsdoc-large-change"></a>
---8<-- "docs/automations/integrations/jsdoc/review-jsdoc-large/README.md"
+## Review JSDoc for Large Changes
+--8<-- "docs/automations/integrations/jsdoc/review-jsdoc-large/README.md:6:"
 [Direct link to this example](/automations/integrations/jsdoc/review-jsdoc-large/)
 
 <a name="review-new-class-jsdoc"></a>
---8<-- "docs/automations/integrations/jsdoc/review-jsdoc-new-class/README.md"
+## Enforce JSDoc for New JavaScript Classes
+--8<-- "docs/automations/integrations/jsdoc/review-jsdoc-new-class/README.md:6:"
 [Direct link to this example](/automations/integrations/jsdoc/review-jsdoc-new-class/)
 
 Special thanks to [Boemo W Mmopelwa](https://github.com/xTrilton) for providing these examples.

--- a/docs/integrations/sonar.md
+++ b/docs/integrations/sonar.md
@@ -15,17 +15,21 @@ SonarCloud Examples:
 * [Review Sonar Security Alerts](#review-sonar-alerts)
 
 <a name="approve-sonar-clean-code"></a>
---8<-- "docs/automations/integrations/sonar/approve-sonar-clean-code/README.md"
+## Approve Sonar Clean Code
+--8<-- "docs/automations/integrations/sonar/approve-sonar-clean-code/README.md:6:"
 [Direct link to this example](/automations/integrations/sonar/approve-sonar-clean-code/)
 
 <a name="label-sonar"></a>
---8<-- "docs/automations/integrations/sonar/label-sonar/README.md"
+## Label SonarCloud Quality Reports
+--8<-- "docs/automations/integrations/sonar/label-sonar/README.md:6:"
 [Direct link to this example](/automations/integrations/sonar/label-sonar/)
 
 <a name="review-sonar-duplications"></a>
---8<-- "docs/automations/integrations/sonar/review-sonar-duplications/README.md"
+## Review Sonar Duplications
+--8<-- "docs/automations/integrations/sonar/review-sonar-duplications/README.md:6:"
 [Direct link to this example](/automations/integrations/sonar/review-sonar-duplications/)
 
 <a name="review-sonar-alerts"></a>
---8<-- "docs/automations/integrations/sonar/review-sonar-alerts/README.md"
+## Review Sonar Security Alerts
+--8<-- "docs/automations/integrations/sonar/review-sonar-alerts/README.md:6:"
 [Direct link to this example](/automations/integrations/sonar/review-sonar-alerts/)

--- a/docs/integrations/swimm.md
+++ b/docs/integrations/swimm.md
@@ -4,4 +4,5 @@ description: Implement workflow automations for Swimm documentation reviews.
 ---
 # Integrate gitStream with Swimm
 
---8<-- "docs/automations/integrations/swimm/approve-swimm/README.md"
+## Approve Swimm Changes
+--8<-- "docs/automations/integrations/swimm/approve-swimm/README.md:6:"


### PR DESCRIPTION
By default, the docs site duplicates meta descriptions for all pages that don't have one explicitely defined, and this has a relatively large negative impact on the SEO performance of the docs site. This PR updates the vast majority of remaining pages to have unique meta descriptions and more descriptive titles.

This PR also makes formatting changes to all of the integrations pages to exclude the meta info and header that are imported from the individual automation pages. It also adds H2s to the integrations pages so that they now construct a RHS navigation.
![Screenshot 2023-07-26 at 3 49 35 PM](https://github.com/linear-b/gitstream/assets/7205829/1db8ec6b-19e7-4797-b468-ec6d74f1cd69)
