### PR TITLE
Fix Integrations page URLs for embedding

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -8,7 +8,7 @@ description: Integrate third-party developer tools with gitStream.
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:simple-sonarcloud: SonarCloud](sonar.md)
+[:simple-sonarcloud: SonarCloud](/integrations/sonar)
 </div>
 <div class="integrations-card-labels">
 Security
@@ -17,7 +17,7 @@ Security
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:simple-dependabot: Dependabot](dependabot.md)
+[:simple-dependabot: Dependabot](/integrations/dependabot)
 </div>
 <div class="integrations-card-labels">
 Security
@@ -26,7 +26,7 @@ Security
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:fontawesome-brands-jira: Jira](jira.md)
+[:fontawesome-brands-jira: Jira](/integrations/jira)
 </div>
 <div class="integrations-card-labels">
 Project Management
@@ -35,7 +35,7 @@ Project Management
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:material-code-braces: Swimm](swimm.md)
+[:material-code-braces: Swimm](/integrations/swimm)
 </div>
 <div class="integrations-card-labels">
 Documentation
@@ -44,7 +44,7 @@ Documentation
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:material-language-java: Javadoc](javadoc.md)
+[:material-language-java: Javadoc](/integrations/javadoc)
 </div>
 <div class="integrations-card-labels">
 Documentation
@@ -53,7 +53,7 @@ Documentation
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:material-language-javascript: JSDoc](jsdoc.md)
+[:material-language-javascript: JSDoc](/integrations/jsdoc)
 </div>
 <div class="integrations-card-labels">
 Documentation
@@ -62,19 +62,10 @@ Documentation
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:material-security: Jit](jit.md)
+[:material-security: Jit](/integrations/jit)
 </div>
 <div class="integrations-card-labels">
 Security
-</div>
-</div>
-
-<div class="integrations-card" markdown="1">
-<div class="integrations-card-title" markdown="1">
-[:material-terraform: Terraform](terraform.md)
-</div>
-<div class="integrations-card-labels">
-Documentation
 </div>
 </div>
 


### PR DESCRIPTION
I forgot to update the URLs on the integrations page to work when they are embedded in other pages.