### PR TITLE
SEO fixes: optimize automation example pages.

### DIFF
--- a/docs/automations/approve-javascript-formatting-change/README.md
+++ b/docs/automations/approve-javascript-formatting-change/README.md
@@ -32,3 +32,14 @@ Approve PRs that only contain formatting changes to JavaScript or TypeScript fil
       [:octicons-download-24: Download this example as a CM file.](/downloads/automation-library/approve_javascript_formatting_change.cm){ .md-button }
       </span>
     </div>
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/safe-merge-automation.md::2"
+--8<-- "docs/snippets/safe-merge-automation.md:4:"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/approve-python-formatting-change/README.md
+++ b/docs/automations/approve-python-formatting-change/README.md
@@ -32,3 +32,14 @@ Approve PRs that only contain formatting changes to Python files.
       [:octicons-download-24: Download this example as a CM file.](/downloads/automation-library/approve_python_formatting_change.cm){ .md-button }
       </span>
     </div>
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/safe-merge-automation.md::2"
+--8<-- "docs/snippets/safe-merge-automation.md:4:"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/approve-safe-changes/README.md
+++ b/docs/automations/approve-safe-changes/README.md
@@ -1,10 +1,11 @@
 ---
 title: gitStream Automation - Approve Safe Changes
-description: Automatically approve PRs for documentation, formatting, and tests.
+description: Automatically approve PRs that change docs, tests, and other safe assets.
 ---
 # Approve Safe Changes
 
-If the PR content only contains one or more of documentation, formatting changes, or tests, automatically approve the PR and apply a safe change label.
+Automatically approve PRs that change docs, tests, and other safe assets.
+
 <div class="automationImage" style="align:right" markdown="1">![Approve safe changes](approve-safe-changes.png)</div>
 <div class="automationDescription" markdown="1">
 !!! info "Configuration Description"
@@ -36,3 +37,13 @@ If the PR content only contains one or more of documentation, formatting changes
 
 
   </style>
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/safe-merge-automation.md:2:"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/approve-team-by-directory/README.md
+++ b/docs/automations/approve-team-by-directory/README.md
@@ -1,9 +1,9 @@
 ---
-title: gitStream Automation - Approve Expert Team
+title: gitStream Automation - Approve Trusted Team
 description: Automatically approve PRs from trusted teams.
 ---
-# Approve Expert Team
-Approve PRs to a specified directory from a specific team. 
+# Approve Trusted Team
+Automatically approve low-risk PRs from trusted teams.
 
 <div class="automationImage" style="align:right" markdown="1">
 ![Approve Expert Team](approve_team_by_directory.png)
@@ -29,3 +29,14 @@ Approve PRs to a specified directory from a specific team.
       [:octicons-download-24: Download this example as a CM file.](/downloads/automation-library/approve_team_by_directory.cm){ .md-button }
       </span>
     </div>
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/safe-merge-automation.md::1"
+--8<-- "docs/snippets/safe-merge-automation.md:3:"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/approve-tiny-changes/README.md
+++ b/docs/automations/approve-tiny-changes/README.md
@@ -30,3 +30,14 @@ Approve single-line changes to a single file.
       [:octicons-download-24: Download this example as a CM file.](/downloads/automation-library/approve_tiny_changes.cm){ .md-button }
       </span>
     </div>
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/safe-merge-automation.md::3"
+--8<-- "docs/snippets/safe-merge-automation.md:5:"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/integrations/javadoc.md
+++ b/docs/integrations/javadoc.md
@@ -14,21 +14,17 @@ Javadoc Examples:
 <a name="review-javadoc"></a>
 ## Review Javadoc Changes
 --8<-- "docs/automations/integrations/javadoc/review-javadoc/README.md:6:"
-[Direct link to this example](/automations/integrations/javadoc/review-javadoc/)
 
 <a name="review-javadoc-input-parameters"></a>
 ## Review Java Input Parameters for Javadoc Changes
 --8<-- "docs/automations/integrations/javadoc/review-javadoc-input-parameters/README.md:6:"
-[Direct link to this example](/automations/integrations/javadoc/review-javadoc-input-parameters/)
 
 <a name="review-javadoc-large-change"></a>
 ## Review Javadoc for Large Changes
 --8<-- "docs/automations/integrations/javadoc/review-javadoc-large-change/README.md:6:"
-[Direct link to this example](/automations/integrations/javadoc/review-javadoc-large-change/)
 
 <a name="review-new-class-javadoc"></a>
 ## Enforce Javadoc Requirements for New Classes
 --8<-- "docs/automations/integrations/javadoc/review-new-class-javadoc/README.md:6:"
-[Direct link to this example](/automations/integrations/javadoc/review-new-class-javadoc/)
 
 Special thanks to [Boemo W Mmopelwa](https://github.com/xTrilton) for providing these examples.

--- a/docs/integrations/jit.md
+++ b/docs/integrations/jit.md
@@ -17,19 +17,15 @@ Jit Examples:
 <a name="review-jit-alerts"></a>
 ## Review Jit Security Alerts
 --8<-- "docs/automations/integrations/jit/review-jit-alerts/README.md:6:"
-[Direct link to this example](/automations/integrations/jit/review-jit-alerts/)
 
 <a name="review-jit-secret"></a>
 ## Review Jit Secret Detection
 --8<-- "docs/automations/integrations/jit/review-jit-secret/README.md:6:"
-[Direct link to this example](/automations/integrations/jit/review-jit-secret/)
 
 <a name="label-jit-alerts"></a>
 ## Label Jit Alerts
 --8<-- "docs/automations/integrations/jit/label-jit-alerts/README.md:6:"
-[Direct link to this example](/automations/integrations/jit/label-jit-alerts/)
 
 <a name="review-jit-ignore-accept"></a>
 ## Review Jit Ignore and Accept
 --8<-- "docs/automations/integrations/jit/review-jit-ignore-accept/README.md:6:"
-[Direct link to this example](/automations/integrations/jit/review-jit-ignore-accept/)

--- a/docs/integrations/jsdoc.md
+++ b/docs/integrations/jsdoc.md
@@ -15,21 +15,17 @@ JSDoc Examples:
 <a name="review-jsdoc"></a>
 ## Review JSDoc Changes
 --8<-- "docs/automations/integrations/jsdoc/review-jsdoc/README.md:6:"
-[Direct link to this example](/automations/integrations/jsdoc/review-jsdoc/)
 
 <a name="review-jsdoc-input-parameters"></a>
 ## Review JSDoc Input Parameters
 --8<-- "docs/automations/integrations/jsdoc/review-jsdoc-input/README.md:6:"
-[Direct link to this example](/automations/integrations/jsdoc/review-jsdoc-input/)
 
 <a name="review-jsdoc-large-change"></a>
 ## Review JSDoc for Large Changes
 --8<-- "docs/automations/integrations/jsdoc/review-jsdoc-large/README.md:6:"
-[Direct link to this example](/automations/integrations/jsdoc/review-jsdoc-large/)
 
 <a name="review-new-class-jsdoc"></a>
 ## Enforce JSDoc for New JavaScript Classes
 --8<-- "docs/automations/integrations/jsdoc/review-jsdoc-new-class/README.md:6:"
-[Direct link to this example](/automations/integrations/jsdoc/review-jsdoc-new-class/)
 
-Special thanks to [Boemo W Mmopelwa](https://github.com/xTrilton) for providing these examples.
+Special thanks to [Boemo W Mmopelwa](https://github.com/xTrilton) for help with these examples.

--- a/docs/integrations/sonar.md
+++ b/docs/integrations/sonar.md
@@ -17,19 +17,15 @@ SonarCloud Examples:
 <a name="approve-sonar-clean-code"></a>
 ## Approve Sonar Clean Code
 --8<-- "docs/automations/integrations/sonar/approve-sonar-clean-code/README.md:6:"
-[Direct link to this example](/automations/integrations/sonar/approve-sonar-clean-code/)
 
 <a name="label-sonar"></a>
 ## Label SonarCloud Quality Reports
 --8<-- "docs/automations/integrations/sonar/label-sonar/README.md:6:"
-[Direct link to this example](/automations/integrations/sonar/label-sonar/)
 
 <a name="review-sonar-duplications"></a>
 ## Review Sonar Duplications
 --8<-- "docs/automations/integrations/sonar/review-sonar-duplications/README.md:6:"
-[Direct link to this example](/automations/integrations/sonar/review-sonar-duplications/)
 
 <a name="review-sonar-alerts"></a>
 ## Review Sonar Security Alerts
 --8<-- "docs/automations/integrations/sonar/review-sonar-alerts/README.md:6:"
-[Direct link to this example](/automations/integrations/sonar/review-sonar-alerts/)

--- a/docs/snippets/automation-footer.md
+++ b/docs/snippets/automation-footer.md
@@ -1,0 +1,1 @@
+More Automations can be found on the [Automation Library](/automations/automation-library) and [Integrations](/integrations) pages.

--- a/docs/snippets/general.md
+++ b/docs/snippets/general.md
@@ -1,0 +1,3 @@
+gitStream is a workflow automation tool that enables you to use YAML configuration files to optimize your code review process. Add context to PRs, find code experts for reviews, and automate the merge process to maximize developer productivity.
+
+[Learn More about how gitStream Works](/how-it-works).

--- a/docs/snippets/safe-merge-automation.md
+++ b/docs/snippets/safe-merge-automation.md
@@ -1,0 +1,6 @@
+* [Automatically approve changes to docs, tests, and other safe assets.](/automations/approve-safe-changes)
+* [Approve low-risk PRs from trusted teams.](/automations/approve-team-by-directory)
+* Approve [Python](/automations/approve-python-formatting-change) or [JavaScript](/automations/approve-javascript-formatting-change) formatting changes.
+* [Approve Tiny Changes](/automations/approve-tiny-changes)
+* Approve [JSDoc](/integrations/jsdoc) or [Javadoc](/integrations/javadoc) changes.
+* [Approve and Merge Dependabot PRs](/integrations/dependabot)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: gitStream 
-site_description: Documentation of gitStream.
-site_author: Ofer Affias
-copyright: Copyright &copy; 2022 LinearB, Inc.
+site_name: gitStream Documentation
+site_description: Automate the code review process with gitStream.
+site_author: LinearB
+copyright: Copyright &copy; 2023 LinearB, Inc.
 repo_url: https://github.com/linear-b/gitstream
 repo_name: linear-b/gitstream
 edit_uri: ""
@@ -24,6 +24,8 @@ nav:
     - Automation actions: automation-actions.md
   - Troubleshooting: troubleshooting.md
   - FAQ: faq.md
+  - Demo: https://app.gitstream.cm/playground
+  - Login: https://app.gitstream.cm/login 
 
 theme:
   name: material


### PR DESCRIPTION
Changes include:
* Removed direct links to individual integration automations from their respective integration landing page. This was throwing off the site structure and creates too many small pages on the site.
* Created some snippets we can use at the bottom of the automation examples to provide helpful resources and beef up the SEO value of key automation examples that are light on word count. I want to see how this impacts our SEO and potentially roll something similar out to more automation examples.
* General site config updates in the mkdocs.yml file to add links and improve overall site SEO.

![Screenshot 2023-07-28 at 2 20 02 PM](https://github.com/linear-b/gitstream/assets/7205829/bb768494-bf12-479c-9df7-050f976797b4)
