### PR TITLE
Add GitHub edit button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_author: LinearB
 copyright: Copyright &copy; 2023 LinearB, Inc.
 repo_url: https://github.com/linear-b/gitstream
 repo_name: linear-b/gitstream
-edit_uri: ""
+edit_uri: "edit/main/docs/"
 
 nav:
   - Overview: index.md
@@ -49,6 +49,7 @@ theme:
       - header.autohide
       - content.code.copy
       - content.code.annotate
+      - content.action.edit
 extra_css:
   - stylesheets/extra.css
 plugins:


### PR DESCRIPTION
This enables a built-in feature to display a button to edit the page you're viewing on GitHub. This will be super helpful when fixing small errors on pages.

![Screenshot 2023-08-23 at 4 47 33 PM](https://github.com/linear-b/gitstream/assets/7205829/1a8921cb-70d4-4922-ac30-99854ae673e8)
