### PR TITLE
fixed the correctness of the regex

### DIFF
--- a/docs/downloads/automation-library/standard/enforce_pr_title.cm
+++ b/docs/downloads/automation-library/standard/enforce_pr_title.cm
@@ -27,4 +27,4 @@ automations:
              * forms
              * http 
 titlePolicy:
-    titleRegex: r/\b(build|ci|docs|feature|fix|)\b\s*\((common|core|elements|forms|http)\):\s*\w+.*
+    titleRegex: r/\b(build|ci|docs|feature|fix)\b\s*\((common|core|elements|forms|http)\):\s*\w+.*/


### PR DESCRIPTION
1. removed trailing or (pipe), as before the fix it match also nothing as TYPE
2. added missing trailing slash as the pattern should be wrapped with 2 slash, r//