### PR TITLE
Corrected indentation in "Additional Reviews for large PR" example

### DIFF
--- a/docs/downloads/automation-library/additional_review_for_large_pr.cm
+++ b/docs/downloads/automation-library/additional_review_for_large_pr.cm
@@ -14,6 +14,6 @@ automations:
         args:
           approvals: 2
       - action: add-comment@v1
-          args:
-            comment: |
-              This PR is a large change and requires 2 reviews.
+        args:
+          comment: |
+            This PR is a large change and requires 2 reviews.


### PR DESCRIPTION
I was recently going through the setup of gitStream and went to implement the [Additional reviewers for large PRs](https://docs.gitstream.cm/automations/additional-review-for-large-pr/) example and found that the provided `.cm` didn't have quite the right formatting on one line. There was some additional indentation for the `args` line that was breaking teh run.

After comparing to the rest of the downloads and verifying the change works in our application, this submission is for those also going through this setup in the future.