### PR TITLE
change linearb Integration link to fully-qualified filepath

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -8,7 +8,7 @@ description: Integrate third-party developer tools with gitStream.
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-<a href=linearb>![LinearB](/downloads/images/linearb-symbol-dark.png#only-light) ![LinearB](/downloads/images/linearb-symbol-white.png#only-dark) LinearB</a>
+<a href=/integrations/linearb>![LinearB](/downloads/images/linearb-symbol-dark.png#only-light) ![LinearB](/downloads/images/linearb-symbol-white.png#only-dark) LinearB</a>
 </div>
 </div>
 


### PR DESCRIPTION
This is required to make the link work when the integrations page is embedded into other locations.