### PR TITLE
Fix prevent com

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -52,6 +52,33 @@ automations:
           comment: |
             A screenshot of the relevant part of docs after the changes is a life saver 🛟
 
+  # Check for wrong app link 
+  check_wrong_domain:
+    if:
+      - {{ source.diff.files | match(attr='diff', regex=r/git[sS]tream\.com/) | some }}
+    run:
+      - action: add-label@v1
+        args:
+          label: 'wrong link'
+          color: '#FF000A'
+      - action: request-changes@v1
+        args:
+          comment: |
+            You have used `gitstream.com` which is not a valid link, use `gitstream.cm` instead.
+
+  # Check for wrong app link 
+  check_local_links:
+    if:
+      - {{ source.diff.files | match(attr='diff', list=['localhost', '127.0.0.1']) | some }}
+    run:
+      - action: add-label@v1
+        args:
+          label: 'wrong link'
+          color: '#FF000A'
+      - action: request-changes@v1
+        args:
+          comment: |
+            You have used local links, use www instead.
 
 has:
   img_type1: {{ pr.description | includes(regex=r/!\[.*\]\(.*(jpg|svg|png|gif|psd).*\)/) }}

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -144,7 +144,7 @@ gitStream supports the use of JavaScript plugins to create new filter functions.
 ## Additional Resources
 
 ### gitStream UI
-Once you have gitStream installed and have run some automations, you can view details about them at [app.gitstream.com](https://app.gitstream.cm). To view gitStream data, you will need to login with your GitHub account and have access to an organization that has run gitStream automations.
+Once you have gitStream installed and have run some automations, you can view details about them at [app.gitstream.cm](https://app.gitstream.cm). To view gitStream data, you will need to login with your GitHub account and have access to an organization that has run gitStream automations.
 
 ![gitStream UI](/screenshots/gitstream-ui.png)
 


### PR DESCRIPTION
1. fix wrong link that use `.com` instead of `.cm`
2. add rules to prevent `gitstream.com` and any use of links with `localhost`

<img width="655" alt="Screenshot 2024-01-26 at 12 42 40" src="https://github.com/linear-b/gitstream/assets/50141/28de2219-54ed-44a5-a89d-239e9b222aa9">
