### PR TITLE
fix usage of secrets in github in all docs

### DIFF
--- a/docs/context-variables.md
+++ b/docs/context-variables.md
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     name: gitStream workflow automation
     env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 ...
 ```
 

--- a/plugins/filters/getCodeowners/README.md
+++ b/plugins/filters/getCodeowners/README.md
@@ -6,11 +6,12 @@ When used, create a secret TOKEN, and add it to the workflow file, in GitHub:
 ```
 jobs:
   gitStream:
+    ...
+    env: 
+      CODEOWNERS: ${{ secrets.GITSTREAM_CODEOWNERS }}
     steps:
       - name: Evaluate Rules
         uses: linear-b/gitstream-github-action@v1
-        env: 
-          CODEOWNERS: ${{ secrets.GITSTREAM_CODEOWNERS }}
 ``` 
 
 ??? note "Plugin Code: getCodeowners"


### PR DESCRIPTION
Fix for the last update with env for serects:
1. wrong indentation 
2. usage in CODEOWNERS example 