### PR TITLE
Fix TODO cm so it will show a comment only for newly added TODO

### DIFF
--- a/docs/downloads/automation-library/standard/review-todo-comments/review_todo_comments.cm
+++ b/docs/downloads/automation-library/standard/review-todo-comments/review_todo_comments.cm
@@ -4,9 +4,9 @@ manifest:
 automations:
   review_todo_comments:
     if:
-      - {{ source.diff.files | matchDiffLines(regex=r/(TODO)|(todo)/) | some }}
-    run: 
+      - {{ source.diff.files | matchDiffLines(regex=r/^[+].*(TODO)|(todo)/) | some }}
+    run:
       - action: request-changes@v1
         args:
-          comment: | 
-                  This PR contains a TODO statement. Please check to see if they should be removed.
+          comment: |
+            This PR contains a TODO statement. Please check to see if they should be removed.


### PR DESCRIPTION
Fix by checking for `+` at the begening of the regex, was checked on these PRs:

1. PR with new line that starts with `# TODO:` - automation was executed
2. PR with existing line that start with `# TODO:` - automation was not executed
3. PR with removed line that start with `# TODO:` - automation was not executed