### PR TITLE
fix typo in example

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -72,7 +72,7 @@ If an automation block does not have explicit triggers configured, it will be tr
 
 - Assign code expert reviewer when the PR is created and after each commit. Ignore branches with the string "hotfix" in them
 ``` yaml+jinja
-triggers
+triggers:
   on:
     - pr_created
     - commit


### PR DESCRIPTION
<img width="727" alt="Screenshot 2024-05-07 at 10 16 45" src="https://github.com/linear-b/gitstream/assets/50141/998f9804-0e44-495e-bfe4-ca59090ca495">
