### PR TITLE
Fix todo example

### DIFF
--- a/docs/downloads/automation-library/standard/review-todo-comments/review_todo_comments.cm
+++ b/docs/downloads/automation-library/standard/review-todo-comments/review_todo_comments.cm
@@ -4,7 +4,7 @@ manifest:
 automations:
   review_todo_comments:
     if:
-      - {{ source.diff.files | matchDiffLines(regex=r/^[+].*(TODO)|(todo)/) | some }}
+      - {{ source.diff.files | matchDiffLines(regex=r/^[+].*(TODO|todo)/) | some }}
     run:
       - action: request-changes@v1
         args:


### PR DESCRIPTION
I encountered an issue in a project I'm contributing to: gitStream would request changes saying my PR has a todo in it, even though I didn't add any todos. I asked another team member if they know what the issue is, and they figured it out: our todo regex was copied from the example in the docs, and that example is incorrect. The current example:
```js
/^[+].*(TODO)|(todo)/
```
It matches:
1. either a line starting with a plus sign, followed by any amount of any characters, followed by `TODO` (uppercase)
2. or it matches any line that has `todo` (lowercase) in it, ignoring the `^[+].*` part

Because of the second part, it reacted to a todo comment I had deleted. This PR fixes this issue by placing both variants (`TODO` and `todo`) inside the same group.

Demo on regex101: [before the change](https://regex101.com/r/G9TJDX/1), [after the change](https://regex101.com/r/G9TJDX/2)