### PR TITLE
fix typo in path of `.gitstream`

### DIFF
--- a/docs/custom-github-app.md
+++ b/docs/custom-github-app.md
@@ -90,7 +90,7 @@ You need to enable these under the permissions section as shown below:
     Add the following Path (content paths to single files the app can access):
 
     1. `.cm/gitstream.cm`
-    2. `github/workflows/gitstream.yml`
+    2. `.github/workflows/gitstream.yml`
 
 ![Permissions Setup 2](screenshots/create-new-github-app-setup-permissions-2.png)
 ![Permissions Setup 3](screenshots/create-new-github-app-setup-permissions-3.png)


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1rBgnnmDi8PQ4mdNnJo1ZPp1EeFC5N58%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=_viO8dm)

fix typo in path of `.gitstream`