### PR TITLE
fix github-installation.md to display images

### DIFF
--- a/docs/github-installation.md
+++ b/docs/github-installation.md
@@ -82,15 +82,14 @@ You can set up gitStream for a single repo or your entire GitHub organization. S
             ```
 
 !!! info "gitStream will now do these two things."
-        When a PR is created or changed, apply or update a label that provides an estimated time to review.
-        ![Estimated Review Time label](screenshots/etr_label_example.png)
-        ![Estimated review time](screenshots/slack-estimated-review-time-example-1-min.png)
-
-        When a new PR is created, comment with a list of code experts.
-        ![Suggested reviewers](screenshots/github-codeexperts-expanded.png)
+    When a PR is created or changed, apply or update a label that provides an estimated time to review.
+    ![Estimated Review Time label](screenshots/etr_label_example.png)
+    ![Estimated review time](screenshots/slack-estimated-review-time-example-1-min.png)
+    When a new PR is created, comment with a list of code experts.
+    ![Suggested reviewers](screenshots/github-codeexperts-expanded.png)
 ## Next Step
 !!! tip "How gitStream Works"
-        Read our guide: [How gitStream Works](/how-it-works/) to get an overview of the gitStream syntax and automation lifecycle.
+    Read our guide: [How gitStream Works](/how-it-works/) to get an overview of the gitStream syntax and automation lifecycle.
 ## Additional Resources
 
 ### Required GitHub Permissions


### PR DESCRIPTION
Changed the spacing from 8 to 4 spaces in the admonition section to render the images and links rather than codeblocks containing markdown.

**Before fix**
<img width="726" alt="Screenshot 2024-09-03 at 8 41 11 PM" src="https://github.com/user-attachments/assets/4468d949-6ec4-4226-8c3f-ae009b0c4dc8">


**After fix**
<img width="732" alt="Screenshot 2024-09-03 at 8 40 08 PM" src="https://github.com/user-attachments/assets/ad13da3f-63ea-482a-a9ac-5a16da11c252">
<img width="708" alt="Screenshot 2024-09-03 at 8 41 33 PM" src="https://github.com/user-attachments/assets/c07df5d6-2e97-46a7-bb81-7da5110a7fba">
