### PR TITLE
fixed link in automations/README.md

### DIFF
--- a/automations/README.md
+++ b/automations/README.md
@@ -1,1 +1,1 @@
-[This content has been moved](docs.gitstream.cm/automations/automation-library/)
+[This content has been moved](https://docs.gitstream.cm/automations/automation-library/)


### PR DESCRIPTION
I prepended `https://` to the automation docs link so it points to the docs webpage rather than a null page in the repo.