### PR TITLE
Fix formatting issues on label-management & branch-management pages

### DIFF
--- a/docs/automations/standard/branch-management/README.md
+++ b/docs/automations/standard/branch-management/README.md
@@ -15,7 +15,8 @@ Use gitStream to enforce branch naming conventions, review assignment, and other
 
 <a name="enforce-branch-name"></a>
 ## Enforce Branch Naming Conventions
---8<-- "docs/automations/standard/branch-management/enforce-branch-name/README.md:6:"
+
+--8<-- "docs/automations/standard/branch-management/enforce-branch-name/README.md:example"
 
 ## Additional Resources
 

--- a/docs/automations/standard/branch-management/enforce-branch-name/README.md
+++ b/docs/automations/standard/branch-management/enforce-branch-name/README.md
@@ -4,7 +4,7 @@ description: Automatically enforce prefixes or keywords in PR branch names.
 category: [review, quality]
 ---
 # Enforce Branch Naming Conventions
-
+<!-- --8<-- [start:example]-->
 Automatically enforce prefixes or keywords in PR branch names.
 
 ![Enforce Branch Naming Conventions](/automations/standard/branch-management/enforce-branch-name/enforce-branch-name.png)
@@ -30,3 +30,14 @@ Automatically enforce prefixes or keywords in PR branch names.
       [:octicons-download-24: Download this example as a CM file.](/downloads/automation-library/standard/branch-management/enforce_branch_name.cm){ .md-button }
       </span>
     </div>
+<!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/review-assignment-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/standard/label-management/README.md
+++ b/docs/automations/standard/label-management/README.md
@@ -9,11 +9,11 @@ Use YAML to automate label management on your git repo with gitStream.
 
 <a name="enforce-required-labels"></a>
 ## Enforce Required Labels
---8<-- "docs/automations/standard/label-management/enforce-labels/README.md:6:"
+--8<-- "docs/automations/standard/label-management/enforce-labels/README.md:example"
 
 <a name="label-changed-resources"></a>
 ## Label Modified Resources
---8<-- "docs/automations/standard/label-management/label-resources-percent/README.md:6:"
+--8<-- "docs/automations/standard/label-management/label-resources-percent/README.md:example"
 
 <a name="label-languages"></a>
 ## Label PRs by Language
@@ -21,15 +21,15 @@ Use YAML to automate label management on your git repo with gitStream.
 
 <a name="label-unresolved-threads"></a>
 ## Label the Number of Unresolved Code Review Threads
---8<-- "docs/automations/standard/label-management/label-unresolved-threads/README.md:6:"
+--8<-- "docs/automations/standard/label-management/label-unresolved-threads/README.md:example"
 
 <a name="suggest-labels"></a>
 ## Automatically Recommend Labels for New PRs
---8<-- "docs/automations/standard/label-management/suggest-labels/README.md:6:"
+--8<-- "docs/automations/standard/label-management/suggest-labels/README.md:example"
 
 <a name="label-approvals"></a>
 ## Label PRs with the Number of Approvals
---8<-- "docs/automations/standard/label-management/label-approvals/README.md:6:"
+--8<-- "docs/automations/standard/label-management/label-approvals/README.md:example"
 
 ## Additional Resources
 

--- a/docs/automations/standard/label-management/enforce-labels/README.md
+++ b/docs/automations/standard/label-management/enforce-labels/README.md
@@ -4,6 +4,7 @@ description: Automatically enforce the use of required PR labels.
 category: [review, quality]
 ---
 # Enforce Required Labels
+<!-- --8<-- [start:example]-->
 Automatically enforce the use of required PR labels.
 
 <div class="automationImage" markdown="1">
@@ -32,3 +33,14 @@ Automatically enforce the use of required PR labels.
       </span>
     </div>
 </div>
+<!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/context-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/standard/label-management/label-approvals/README.md
+++ b/docs/automations/standard/label-management/label-approvals/README.md
@@ -4,7 +4,7 @@ description: Automatically label PRs with the number of completed reviews that a
 category: [review]
 ---
 # Label the Number of Approvals
-
+<!-- --8<-- [start:example]-->
 Automatically label PRs with the number of completed reviews that approve the PR.
 
 <div class="automationImage" markdown="1">
@@ -32,3 +32,15 @@ Automatically label PRs with the number of completed reviews that approve the PR
       </span>
     </div>
 </div>
+
+<!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/context-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/standard/label-management/label-modified-resources/README.md
+++ b/docs/automations/standard/label-management/label-modified-resources/README.md
@@ -28,3 +28,13 @@ Automatically label PRs to indicate what resources are being changed.
     </div>
 
 <!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/context-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/standard/label-management/label-prs-by-language/README.md
+++ b/docs/automations/standard/label-management/label-prs-by-language/README.md
@@ -30,3 +30,13 @@ Automatically detect which programming languages are contained in PRs and automa
     </div>
 
 <!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/context-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/standard/label-management/label-resources-percent/README.md
+++ b/docs/automations/standard/label-management/label-resources-percent/README.md
@@ -4,6 +4,7 @@ description: Automatically label PRs based on changes to code resources.
 category: [review]
 ---
 # Label Changed Resources By Percent
+<!-- --8<-- [start:example]-->
 
 Apply a label to all PRs that indicates what percentage of new lines of code modify one or more specified resources.
 
@@ -32,3 +33,15 @@ Apply a label to all PRs that indicates what percentage of new lines of code mod
       </span>
     </div>
 </div>
+
+<!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/context-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/standard/label-management/label-unresolved-threads/README.md
+++ b/docs/automations/standard/label-management/label-unresolved-threads/README.md
@@ -5,6 +5,7 @@ category: [security]
 quickstart: true
 ---
 # Label Unresolved Review Threads
+<!-- --8<-- [start:example]-->
 Automatically label PRs when there are unresolved code review comments.
 
 <div class="automationImage" markdown="1">
@@ -32,3 +33,15 @@ Automatically label PRs when there are unresolved code review comments.
       </span>
     </div>
 </div>
+
+<!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/context-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"

--- a/docs/automations/standard/label-management/suggest-labels/README.md
+++ b/docs/automations/standard/label-management/suggest-labels/README.md
@@ -4,6 +4,7 @@ description: Automatically suggest labels to apply to new PRs.
 category: [review]
 ---
 # Suggest Labels
+<!-- --8<-- [start:example]-->
 Automatically suggest labels to apply to new PRs.
 
 <div class="automationImage" markdown="1">
@@ -31,3 +32,15 @@ Automatically suggest labels to apply to new PRs.
       </span>
     </div>
 </div>
+
+<!-- --8<-- [end:example]-->
+
+## Additional Resources
+
+--8<-- "docs/snippets/general.md"
+
+**Related Automations**:
+
+--8<-- "docs/snippets/context-automation.md"
+
+--8<-- "docs/snippets/automation-footer.md"


### PR DESCRIPTION
- Fixes #463 
- Fixes formatting so that there is now a single header per example for:
   - https://docs.gitstream.cm/automations/standard/branch-management/ 
   - https://docs.gitstream.cm/automations/standard/label-management/ 
- Adds footers that are consistent with the parent page to:
  - https://docs.gitstream.cm/automations/standard/branch-management/enforce-branch-name
  - https://docs.gitstream.cm/automations/standard/label-management/enforce-labels
  - https://docs.gitstream.cm/automations/standard/label-management/label-approvals
  - https://docs.gitstream.cm/automations/standard/label-management/label-modified-resources
  - https://docs.gitstream.cm/automations/standard/label-management/label-prs-by-language
  - https://docs.gitstream.cm/automations/standard/label-management/label-resources-percent
  - https://docs.gitstream.cm/automations/standard/label-management/label-unresolved-threads
  - https://docs.gitstream.cm/automations/standard/label-management/suggest-labels


