### PR TITLE
Fix formatting in cm files

### DIFF
--- a/docs/downloads/javascript.cm
+++ b/docs/downloads/javascript.cm
@@ -1,6 +1,6 @@
 # -*- mode: yaml -*-
 manifest:
-	version: 1.0
+  version: 1.0
 
 automations:
   # Uses the isFormattingChange filter function to automatically approve non-functional changes. 
@@ -23,6 +23,6 @@ automations:
       - {{ source.diff.files | matchDiffLines(regex=r/^[+-].*console\.log/, ignoreWhiteSpaces=true) | every }}
     run: 
       - action: add-label@v1
-          args:
-            label: 'prints-changes'
+        args:
+          label: 'prints-changes'
       - action: approve@v1

--- a/docs/downloads/organization.cm
+++ b/docs/downloads/organization.cm
@@ -1,10 +1,10 @@
 # -*- mode: yaml -*-
 manifest:
-	version: 1.0
+  version: 1.0
     
 automations:
   # Assign reviewers at random to spread knowledge of a particular repo.
-	share_knowledge:
+  share_knowledge:
     # Triggered for PRs to the `new-repo` repository.
     if:
       - {{ repo.name | match(term='new-repo') }}

--- a/docs/downloads/python.cm
+++ b/docs/downloads/python.cm
@@ -1,6 +1,6 @@
 # -*- mode: yaml -*-
 manifest:
-	version: 1.0
+  version: 1.0
 
 automations:
   # Approve PRs that only change logging functionality.


### PR DESCRIPTION
Really simple fix to remove tabs from the cm files so that they are valid YAML.

Fixed files:
- docs/downloads/javascript.cm
- docs/downloads/organization.cm
- docs/downloads/python.cm