### PR TITLE
Fix Grammatical Error in GitHub Setup Docs

### DIFF
--- a/docs/downloads/gitstream.cm
+++ b/docs/downloads/gitstream.cm
@@ -1,5 +1,5 @@
 # -*- mode: yaml -*-
-# This example configuration for provides basic automations to get started with gitStream.
+# This example configuration provides basic automations to get started with gitStream.
 # View the gitStream quickstart for more examples: https://docs.gitstream.cm/examples/
 manifest:
   version: 1.0


### PR DESCRIPTION
Grammatical error found in the GitStream docs configuration description 