### PR TITLE
enforce `gitstream` in bb user name

### DIFF
--- a/docs/bitbucket-installation.md
+++ b/docs/bitbucket-installation.md
@@ -14,6 +14,7 @@ description: Install gitStream to your Bitbucket workspace.
     1. Bitbucket Cloud account
     2. Bitbucket Pipelines enabled
     3. <a href="https://app.linearb.io/login" target="_blank">Login</a>, or <a href="https://app.linearb.io/sign-up" target="_blank">create a free account</a> on the LinearB app, and follow the steps to connect gitStream using a Bitbucket integration.
+    4. A dedicated user for gitStream, whose name includes the term **"gitstream"**.  
 
 Bitbucket Installation Overview
 
@@ -24,9 +25,7 @@ Bitbucket Installation Overview
 
 ## Designate a gitStream User Account
 
-gitStream automation rules are executed on behalf of the user account configured when you install the gitStream service. This account must have the necessary permissions to the relevant repositories.
-
-We recommend creating a dedicated service account to easily control access to individual repositories. You can also use your professional or personal Bitbucket account for this, resulting in all automations being executed under that account.
+gitStream automation rules are executed by the user account configured when you authorize LinearB. A meaningful account identifier whose name contains the string `gitstream` (case insensitive), such as `gitStream-cm`, is required to ensure clarity and proper identification of the automated actions. This account must have the necessary permissions to the relevant repositories.
 
 !!! tip "Use this account when you integrate gitStream"
     Make sure to use this account when authorizing Bitbucket in LinearB.


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19soDZDlDBp40g7HdV7LO7FY8Nu3Px8AGo%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=X8sKwei)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose:
Updates the Bitbucket installation documentation to require a dedicated gitStream user account with specific naming convention.

Main changes:
- Adds new prerequisite requiring dedicated user with "gitstream" in the name
- Modifies user account section to specify naming requirement (must contain "gitstream")
- Simplifies language around user account configuration and permissions
<!--end_gitstream_placeholder-->
