### PR TITLE
Add uv.lock to exclude list

### DIFF
--- a/plugins/filters/askAI/index.js
+++ b/plugins/filters/askAI/index.js
@@ -36,7 +36,8 @@ const LOCK_FILES = [
   'Podfile.lock',
   'Cartfile.resolved',
   'flake.lock',
-  'pnpm-lock.yaml'
+  'pnpm-lock.yaml',
+  'uv.lock'
 ];
 const EXCLUDE_EXPRESSIONS_LIST = [
   '.*\\.(ini|csv|xls|xlsx|xlr|doc|docx|txt|pps|ppt|pptx|dot|dotx|log|tar|rtf|dat|ipynb|po|profile|object|obj|dxf|twb|bcsymbolmap|tfstate|pdf|rbi|pem|crt|svg|png|jpeg|jpg|ttf)$',


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1fEfPgyRUxWJ7vhJWfgmGtlAiJTsveQA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=SQuC463)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Adds support for uv.lock file to the list of lock files that should be excluded from AI analysis.

Main changes:
- Added 'uv.lock' to the LOCK_FILES array

*This description was generated by LinearB AI and added by gitStream*.
<!--end_gitstream_placeholder-->
