### PR TITLE
Fix codeowners filter name to match filename

### DIFF
--- a/plugins/filters/getCodeowners/get_codeowners.cm
+++ b/plugins/filters/getCodeowners/get_codeowners.cm
@@ -15,4 +15,4 @@ automations:
           reviewers: {{ experts | intersection(list=owners) }}
 
 experts: {{ repo | codeExperts(gt=10) }}
-owners: {{ files | codeowners(pr, env.CODEOWNERS) }}
+owners: {{ files | getCodeowners(pr, env.CODEOWNERS) }}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Rename the 'codeowners' filter to 'getCodeowners' for better clarity in functionality.

Main changes:
- Updated filter name from 'codeowners' to 'getCodeowners' in code ownership lookup functionality

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
