### PR TITLE
Rename AI integration to "Bring Your Own AI"

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -6,7 +6,7 @@ visible: false
 # gitStream Integrations
 <!-- --8<-- [start:integrations]-->
 <div class="integrations-list" markdown="1">
-  
+
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
 <a href=/integrations/linearb>![LinearB](/downloads/images/linearb-symbol-dark.png#only-light) ![LinearB](/downloads/images/linearb-symbol-white.png#only-dark) LinearB</a>
@@ -21,7 +21,7 @@ visible: false
 
 <div class="integrations-card" markdown="1">
 <div class="integrations-card-title" markdown="1">
-[:fontawesome-solid-wand-magic-sparkles: askAI](/integrations/askAI)
+[:fontawesome-solid-wand-magic-sparkles: Bring Your Own AI](/integrations/askAI)
 </div>
 </div>
 

--- a/docs/integrations/askAI.md
+++ b/docs/integrations/askAI.md
@@ -1,13 +1,13 @@
 ---
-title: Integrate gitStream with AI
+title: Integrate gitStream with Your Own AI
 description: Use gitStream to integrate with AI services for Review, describe and add tests.
 category: [quality, genai, copilot, tests, efficiency]
 ---
-# Integrate gitStream with AI
+# Integrate gitStream with your own AI
 
 <!-- --8<-- [start:examples]-->
 !!! warning "Required gitStream Plugins"
-    This example requires you to install the [`askAI`](/filter-function-plugins/#askai) plugin.
+    To use these examples, you need to install the [`askAI`](/filter-function-plugins/#askai) plugin and provide your own AI service API key.
 
     [Learn more about gitStream plugins](/plugins/).
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Updates the documentation to clarify that users need to provide their own AI service API key and renames the askAI integration to "Bring Your Own AI".

Main changes:
- Renamed askAI integration to "Bring Your Own AI" in navigation and titles
- Added clarification about requiring user's own AI service API key
- Updated warning section with clearer plugin requirements

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
