### PR TITLE
Update gitStream connection IPs in custom GitHub app docs

### DIFF
--- a/docs/custom-github-app.md
+++ b/docs/custom-github-app.md
@@ -14,8 +14,8 @@ A GitHub application serves as the link between gitStream and GitHub. It facilit
 !!! Info "Prerequisites"
     1. GitHub Server v3.10 or higher
     2. Allowed network connection between the server and the following IPs:
-        - 54.241.87.26
-        - 54.193.121.186
+        - 13.56.203.235
+        - 54.151.81.98
 
 In this section, we'll guide you through creating a GitHub app for your self-hosted gitStream installation. By the end, you should have noted down the following values:
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update the IP addresses required for network connection between GitHub Server and gitStream services.

Main changes:
- Replaced old IP 54.241.87.26 with new IP 13.56.203.235
- Replaced old IP 54.193.121.186 with new IP 54.151.81.98

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
