### PR TITLE
add to BB, GL, GH

### DIFF
--- a/docs/bitbucket-installation.md
+++ b/docs/bitbucket-installation.md
@@ -15,6 +15,9 @@ description: Install gitStream to your Bitbucket workspace.
     2. Bitbucket Pipelines enabled
     3. <a href="https://app.linearb.io/login" target="_blank">Login</a>, or <a href="https://app.linearb.io/sign-up" target="_blank">create a free account</a> on the LinearB app, and follow the steps to connect gitStream using a Bitbucket integration.
     4. A dedicated user for gitStream, whose name includes the term **"gitstream"**.  
+    5. Allowed network connection between the runners and the following IPs:
+        - 13.56.203.235
+        - 54.151.81.98
 
 Bitbucket Installation Overview
 

--- a/docs/github-installation.md
+++ b/docs/github-installation.md
@@ -4,6 +4,11 @@ description: Install gitStream to your GitHub organization.
 ---
 # How to Setup gitStream with GitHub
 
+!!! Info "Prerequisites"
+    Allowed network connection between the runners and the following IPs:
+        - 13.56.203.235
+        - 54.151.81.98
+
 !!! Warning "Install gitStream"
 
     Before you can complete the gitStream setup process, you need to install the gitStream app to your [GitHub organization](https://github.com/apps/gitstream-cm/installations/new){ .md-button }.

--- a/docs/gitlab-installation.md
+++ b/docs/gitlab-installation.md
@@ -9,6 +9,9 @@ description: Install gitStream to your GitLab organization.
     1. GitLab
     2. GitLab runner v15 or higher with ability to run apk commands
     3. <a href="https://app.linearb.io/login" target="_blank">Login</a>, or <a href="https://app.linearb.io/sign-up" target="_blank">create a free account</a> on the LinearB app, and follow the steps to <a href="https://linearb.helpdocs.io/article/0xxpvue4s9-connect-git-stream-using-a-git-lab-integration" target="_blank">connect gitStream Using a GitLab Integration</a>.
+    4. Allowed network connection between the executors and the following IPs:
+        - 13.56.203.235
+        - 54.151.81.98
 
 GitLab Installation Overview
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add network connectivity requirements to access gitStream's services for Bitbucket, GitHub, and GitLab installations.

Main changes:
- Added prerequisite: Allow network connections to IPs 13.56.203.235 and 54.151.81.98 for all platforms
- Updated installation documentation to include network requirements in each platform's prerequisites section

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
