### PR TITLE
Rename execution model documentation to trigger control

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,4 +1,4 @@
-# Execution Model
+# Trigger Control
 
 gitStream is triggered on new pull requests (PRs) for repositories that have gitStream installed. Upon triggering, gitStream collects context variables and evaluates the automation rules to determine which ones are relevant.
 
@@ -10,12 +10,12 @@ When a central `cm` repository is set with the CI/CD runner, the events for PRs 
 
 Free accounts have a monthly limit on the number of PRs that can trigger automations. Once this limit is reached:
 
-- PRs will still be created, but gitStream will skip automations for them.  
-- The gitStream check on these PRs will be concluded as `Skipped`, to ensure that gitStream will not block the PR from merging.  
-- A warning is displayed in PR comments when the organization reaches 90% of its quota.  
-- The limit resets at the start of each month.  
+- PRs will still be created, but gitStream will skip automations for them.
+- The gitStream check on these PRs will be concluded as `Skipped`, to ensure that gitStream will not block the PR from merging.
+- A warning is displayed in PR comments when the organization reaches 90% of its quota.
+- The limit resets at the start of each month.
 
-To remove automation limits, <a href="https://linearb.io/contact-us" target="_blank">Contact LinearB</a> and upgrade to a paid plan.  
+To remove automation limits, <a href="https://linearb.io/contact-us" target="_blank">Contact LinearB</a> and upgrade to a paid plan.
 🔗 Learn more: [Automation Limits](limits.md)
 
 ## Triggering Mechanism
@@ -70,6 +70,9 @@ The table below lists supported explicit triggers, categorized into those enable
 
 Explicit triggers are set independently per each automation block and can be configured at the file level, specific to each automation separately or in combination. If triggers are listed at the file level **and** specific automation, the automation will be triggered according to both triggers.
 If an automation block does not have explicit triggers configured, it will be triggered according to the default (implicit) triggers.
+
+!!! Note
+    The `on` parameter can be used within individual automation blocks, while `triggers.include` and `triggers.exclude` can only be defined at the file level.
 
 **Note on Matching:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
   - Integrations: integrations/README.md
   - Reference:
     - Configuration: cm-file.md
-    - Execution: execution-model.md
+    - Trigger Control: execution-model.md
     - Automation Limits: limits.md
     - Context variables: context-variables.md
     - Filter functions: filter-functions.md


### PR DESCRIPTION
AI: Rename "Execution Model" to "Trigger Control" in docs

Document that `on` parameter can be used within individual automation blocks, while `triggers.include` and `triggers.exclude` are file-level only.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: This PR updates the Trigger Control documentation and renames the "Execution Model" section to "Trigger Control" for clarity.

Main changes:
- Renamed "Execution Model" to "Trigger Control" in docs and navigation
- Added a note about the usage of 'on' parameter and triggers.include/exclude
- Minor formatting and content adjustments throughout the document

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
