### PR TITLE
Update excluded file types for code review

### DIFF
--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -318,9 +318,10 @@ The following files are automatically excluded from the code review.
 
 | File type | Filter type | Values|
 | - | - | - |
-| Data | Extension | `ini` `csv` `xls` `xlsx` `xlr` `doc` `docx` `txt` `pps` `ppt` `pptx` `dot` `dotx` `log` `tar` `rtf` `dat` `ipynb` `po` `profile` `object` `obj` `dxf` `twb` `bcsymbolmap` `tfstate` `pdf` `rbi` `pem` `crt` `svg` `png` `jpeg` `jpg` `ttf` |
-| Data | Regex | `.*dist/.*\.js$` `.*public/assets/.*\.js$` |
-| Pipeline | Regex | `.*ci\.yml$` |
+| Data | Extension | `ini` `csv` `xls` `xlsx` `xlr` `doc` `docx` `txt` `pps` `ppt` `pptx` `dot` `dotx` `log` `tar` `rtf` `dat` `ipynb` `po` `profile` `object` `obj` `dxf` `twb` `bcsymbolmap` `tfstate` `pdf` `rbi` `pem` `crt` `svg` `png` `jpeg` `jpg` `ttf` `app` `bin` `bmp` `bz2` `class` `db` `dll` `dylib` `egg` `eot` `exe` `gif` `gitignore` `glif` `gradle` `gz` `ico` `jar` `lo` `lock` `mp3` `mp4` `nar` `o` `ogg` `otf` `p` `pickle` `pkl` `pyc` `pyd` `pyo` `rkt` `so` `ss` `tgz` `tsv` `war` `webm` `woff` `woff2` `xz` `zip` `zst` `snap` `lockb` |
+| Lock | Regex | `.*(yarn\|gemfile\|podfile\|cargo\|composer\|pipfile\|gopkg)\.lock$` `.*gradle\.lockfile$` `.*lock\.sbt$` |
+| Build | Regex | `.*dist/.*\\.js` `.*build/.*\\.js` |
+| Data | Regex | `.*public/assets/.*\\.js` |
 
 | Lock File Name          | Programming Language | Package Manager      |
 |-------------------------|----------------------|----------------------|


### PR DESCRIPTION
AI no longer filters pipeline CI files, adds many binary & lock file exclusions, and organizes JS exclusions under better categories.

<img width="726" alt="Screenshot 2025-04-21 at 22 31 56" src="https://github.com/user-attachments/assets/1c430ebf-e41b-48ba-9c0b-5e4a2816981e" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose and impact: This PR expands the list of file types automatically excluded from code review and adds new regex patterns for filtering lock and build files.

Main changes:
- Adds numerous file extensions to the Data exclusion list
- Introduces new Lock and Build regex patterns for file exclusion
- Moves some existing regex patterns to more specific categories

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
