### PR TITLE
Add 'on' event triggers to Dependabot automation examples

### DIFF
--- a/docs/downloads/automation-library/integrations/dependabot/approve_dependabot.cm
+++ b/docs/downloads/automation-library/integrations/dependabot/approve_dependabot.cm
@@ -5,6 +5,9 @@ manifest:
 
 automations:
   approve_dependabot:
+    on:
+      - pr_created
+      - commit
     if:
       - {{ branch.name | includes(term="dependabot") }}
       - {{ branch.author | includes(term="dependabot") }}

--- a/docs/downloads/automation-library/integrations/dependabot/approve_dependabot_minor.cm
+++ b/docs/downloads/automation-library/integrations/dependabot/approve_dependabot_minor.cm
@@ -3,6 +3,9 @@ manifest:
 
 automations:
   merge_dependabot_minor:
+    on:
+      - pr_created
+      - commit
     if:
       - {{ bump == 'minor' }}
       - {{ branch.name | includes(term="dependabot") }}
@@ -14,6 +17,9 @@ automations:
           comment: |
             Dependabot `minor` version bumps are approved automatically.
   merge_dependabot_minor_patch:
+    on:
+      - pr_created
+      - commit
     if:
       - {{ bump == 'patch' }}
       - {{ branch.name | includes(term="dependabot") }}

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -42,6 +42,7 @@ The `triggers` section in gitStream gives you precise control over when automati
 
 Additionally, the `on` keyword defines specific events that trigger automations. It can be added at the file level (under the `triggers` section) or within individual automations for greater customization. Multiple triggers can be stacked, meaning gitStream will execute the automation for each matching triggering event, allowing flexibility in defining automation behavior
 
+<div class="trigger-details" markdown=1>
 | Key                                                   | Type              | Description                                                    |
 | ----------------------------------------------------- | ----------------- | -------------------------------------------------------------- |
 | `triggers.on` :fontawesome-brands-github:             | [String]          | Specifies the explicit triggers that initiate the automations. |
@@ -49,9 +50,11 @@ Additionally, the `on` keyword defines specific events that trigger automations.
 | `triggers.exclude.branch` :fontawesome-brands-github: | [String or regex] | Branches that match will not trigger the automation.           |
 | `triggers.include.repository`                         | [String or regex] | Repositories that match will trigger the automation.           |
 | `triggers.exclude.repository`                         | [String or regex] | Repositories that match will not trigger the automation.       |
+</div>
 
 The table below lists supported explicit triggers, categorized into those enabled by default and those that require manual activation.
 
+<div class="trigger-details" markdown=1>
 | Triggering event                                                      | Explicit Trigger :fontawesome-brands-github: | Default (implicit triggers)    |
 | --------------------------------------------------------------------- | -------------------------------------------- | ------------------------------ |
 | Creating a PR                                                         | `pr_created`                                 | `on`                           |
@@ -67,6 +70,7 @@ The table below lists supported explicit triggers, categorized into those enable
 | :fontawesome-brands-github: transition from any state to closed       | `pr_closed`                                  | `off`                          |
 | :fontawesome-brands-github: transition from closed to open            | `pr_reopened`                                | `off`                          |
 | :fontawesome-brands-github: Transition from any state to approved     | `pr_approved`                                | If there is an automation with one of the actions: `require-reviewers`, `set-required-approvals` or `merge`, or uses `pr.approvals` context variable  |
+</div>
 
 Explicit triggers are set independently per each automation block and can be configured at the file level, specific to each automation separately or in combination. If triggers are listed at the file level **and** specific automation, the automation will be triggered according to both triggers.
 If an automation block does not have explicit triggers configured, it will be triggered according to the default (implicit) triggers.
@@ -145,6 +149,9 @@ triggers:
 
 automations:
   bump_minor:
+    on:
+      - pr_created
+      - commit
     if:
       - {{ bump == 'minor' }}
       - {{ branch.name | includes(term="dependabot") }}
@@ -157,6 +164,9 @@ automations:
             Dependabot `minor` version bumps are approved automatically.
 
   bump_patch:
+    on:
+      - pr_created
+      - commit
     if:
       - {{ bump == 'patch' }}
       - {{ branch.name | includes(term="dependabot") }}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -5,11 +5,11 @@
 
 h2 {
   padding-top: 4%;
-} 
+}
 
 h4 {
   padding-top: 4%;
-} 
+}
 
 /* make the first column wider as usually this is a variable name that cant wrap normally */
 th:nth-child(1){
@@ -22,6 +22,10 @@ div.big-summary th:nth-child(1){
 
 div.filter-details th:nth-child(1){
     width: 20%;
+}
+
+div.trigger-details th:nth-child(2){
+    width: 30%;
 }
 
 /* change the table colors for light mode */
@@ -104,7 +108,7 @@ div.flow-chart {
   color: gray;
 }
 
-.tabbed-content .md-typeset .admonition { 
+.tabbed-content .md-typeset .admonition {
   font-size: .8rem;
 }
 
@@ -178,7 +182,7 @@ div.flow-chart {
   width:auto;
   height: 3em;
 }
-  
+
 .integrations-card-labels {
   font-size: 0.7em;
   color: #9aa4ad; /* this is a medium grey color */

--- a/plugins/filters/extractDependabotVersionBump/extract_dependabot_version_bump.cm
+++ b/plugins/filters/extractDependabotVersionBump/extract_dependabot_version_bump.cm
@@ -3,6 +3,9 @@ manifest:
 
 automations:
   bump_minor:
+    on:
+      - pr_created
+      - commit
     if:
       - {{ bump == 'minor' }}
       - {{ branch.name | includes(term="dependabot") }}
@@ -15,6 +18,9 @@ automations:
             Dependabot `minor` version bumps are approved automatically.
 
   bump_patch:
+    on:
+      - pr_created
+      - commit
     if:
       - {{ bump == 'patch' }}
       - {{ branch.name | includes(term="dependabot") }}


### PR DESCRIPTION
Improve layout of triggers defaults

Bug: https://linearb.atlassian.net/browse/LINBEE-16194

<img width="795" alt="Screenshot 2025-04-24 at 12 48 05" src="https://github.com/user-attachments/assets/8310b520-ff6d-4efb-a1fb-7f8e4eba51f4" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: This PR adds explicit triggers to Dependabot-related automations and updates documentation on trigger control.

Main changes:
- Added 'on' triggers (pr_created and commit) to Dependabot automations
- Updated execution-model.md with detailed information on explicit triggers
- Adjusted CSS styling for trigger details in documentation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
