### PR TITLE
Add triggers to suggest-code-experts examples

### DIFF
--- a/docs/automations/standard/explain-code-experts/README.md
+++ b/docs/automations/standard/explain-code-experts/README.md
@@ -15,11 +15,17 @@ Post a comment that uses git blame and history to list the most relevant experts
 !!! info "Configuration Description"
     Conditions (all must be true):
 
-    * A PR is created or modified.
+    * The PR has the 'suggest-reviewer' label.
+
+    Explicit Triggers:
+    
+    * When a PR is created (`pr_created`)
+    * When a PR becomes ready for review (`pr_ready_for_review`)
+    * When a new commit is pushed to the PR (`commit`)
 
     Automation Actions:
 
-    * Post a comment that identifies the people with the highest level of code expetise.
+    * Post a comment that identifies the people with the highest level of code expertise.
 
 </div>
 <div class="automationExample" markdown="1">

--- a/docs/downloads/automation-library/standard/explain_code_experts.cm
+++ b/docs/downloads/automation-library/standard/explain_code_experts.cm
@@ -5,9 +5,13 @@ manifest:
 
 automations:
   explain_code_experts:
+    on:
+      - pr_created
+      - pr_ready_for_review
+      - commit
     if:
       - {{ pr.labels | match(term='suggest-reviewer') | some }}
     run:
-      - action: explain-code-experts@v1 
+      - action: explain-code-experts@v1
         args:
-          gt: 10 
+          gt: 10

--- a/docs/downloads/gitStream-gl.cm
+++ b/docs/downloads/gitStream-gl.cm
@@ -52,9 +52,9 @@ automations:
     if:
       - true
     run:
-      - action: explain-code-experts@v1 
+      - action: explain-code-experts@v1
         args:
-          gt: 10 
+          gt: 10
 
 
 # +----------------------------------------------------------------------------+

--- a/docs/downloads/github/gitstream.cm
+++ b/docs/downloads/github/gitstream.cm
@@ -40,6 +40,7 @@ automations:
   explain_code_experts:
     on:
       - pr_created
+      - pr_ready_for_review
       - commit
     if:
       - true

--- a/docs/downloads/gitstream.cm
+++ b/docs/downloads/gitstream.cm
@@ -55,12 +55,16 @@ automations:
             Please add a Jira ticket reference to the title or description of this PR.
   # Post a comment that lists the best experts for the files that were modified.
   explain_code_experts:
+    on:
+      - pr_created
+      - pr_ready_for_review
+      - commit
     if:
       - true
     run:
-      - action: explain-code-experts@v1 
+      - action: explain-code-experts@v1
         args:
-          gt: 10 
+          gt: 10
 
 
 # +----------------------------------------------------------------------------+

--- a/docs/downloads/sales_demo.cm
+++ b/docs/downloads/sales_demo.cm
@@ -40,12 +40,16 @@ automations:
           label: '🤖 Copilot'
   # Post a comment that lists the best experts for the files that were modified.
   explain_code_experts:
+    on:
+      - pr_created
+      - pr_ready_for_review
+      - commit
     if:
       - true
     run:
-      - action: explain-code-experts@v1 
+      - action: explain-code-experts@v1
         args:
-          gt: 10 
+          gt: 10
 
 
 # +----------------------------------------------------------------------------+


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose and impact:
This PR updates the "Explain Code Experts" automation to trigger on specific events and only for PRs with a 'suggest-reviewer' label.

Main changes:
- Added explicit triggers for PR creation, ready for review, and new commits
- Changed condition to only run on PRs with 'suggest-reviewer' label
- Updated documentation to reflect new trigger conditions and label requirement

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We’d love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
