### PR TITLE
update docs with bitbucket triggers warning

### DIFF
--- a/docs/bitbucket-installation.md
+++ b/docs/bitbucket-installation.md
@@ -5,16 +5,16 @@ description: Install gitStream to your Bitbucket workspace.
 # How to Setup gitStream with Bitbucket Cloud
 
 !!! info "gitStream for Bitbucket Cloud is currently in **beta**"
-    
-    To start automating your Bitbucket pull requests and enhancing your development workflow, please [contact our product team](mailto:product@linearb.io) to request access and receive setup instructions.  
-    We’d love to hear your feedback and collaborate to improve this integration during the beta phase. Thank you for your interest!  
+
+    To start automating your Bitbucket pull requests and enhancing your development workflow, please [contact our product team](mailto:product@linearb.io) to request access and receive setup instructions.
+    We’d love to hear your feedback and collaborate to improve this integration during the beta phase. Thank you for your interest!
 
 !!! info "Prerequisites"
 
     1. Bitbucket Cloud account
     2. Bitbucket Pipelines enabled
     3. <a href="https://app.linearb.io/login" target="_blank">Login</a>, or <a href="https://app.linearb.io/sign-up" target="_blank">create a free account</a> on the LinearB app, and follow the steps to connect gitStream using a Bitbucket integration.
-    4. A dedicated user for gitStream, whose name includes the term **"gitstream"**.  
+    4. A dedicated user for gitStream, whose name includes the term **"gitstream"**.
     5. Allowed network connection between the runners and the following IPs:
         - 13.56.203.235
         - 54.151.81.98
@@ -40,7 +40,7 @@ Create a `cm` repository in your Bitbucket workspace. This repository must resid
 !!! info "Configuration File Locations"
 	Group-level rules require your `.cm` files to be placed in the `cm` repository's root directory.
 	You can also define specific repo-level rules under the `.cm` folder in each of the connected repositories
- 
+
 !!! example "Example Configuration"
     ```yaml
     --8<-- "docs/downloads/gitstream-bb.cm"
@@ -54,8 +54,11 @@ Once your gitStream configuration file is set up, you need a Bitbucket Pipelines
 --8<-- "docs/downloads/bitbucket-pipelines.yml"
 ```
 
-!!! warning "Note"
+!!! warning "Labels are not supported"
     The `add-label` action is not supported in Bitbucket as Bitbucket does not have a native labeling feature.
+
+!!! warning "Explicit triggers are not supported"
+    The `triggers` and `on` functionality are not currently supported in Bitbucket. If you include them in your CM automation files, gitStream will ignore them and will use the default triggering as sepecified in [`Trigger Control`](./execution-model.md#triggers-section).
 
 ## Install the gitStream Service
 
@@ -81,6 +84,6 @@ The required permissions are:
 | `pullrequest: read, write`                          | Read and modify pull requests.                               |
 | `webhook: read, write`                              | Read and manage webhooks.                                    |
 | `pipeline: read, write`                             | Read and write pipelines.                                    |
-| `runner: read, write`                               | Read and manage runners.   
+| `runner: read, write`                               | Read and manage runners.
 
 </markdown>

--- a/docs/bitbucket-installation.md
+++ b/docs/bitbucket-installation.md
@@ -58,7 +58,7 @@ Once your gitStream configuration file is set up, you need a Bitbucket Pipelines
     The `add-label` action is not supported in Bitbucket as Bitbucket does not have a native labeling feature.
 
 !!! warning "Explicit triggers are not supported"
-    The `triggers` and `on` functionality are not currently supported in Bitbucket. If you include them in your CM automation files, gitStream will ignore them and will use the default triggering as sepecified in [`Trigger Control`](./execution-model.md#triggers-section).
+    The `triggers` and `on` functionality are not currently supported in Bitbucket. If you include them in your CM automation files, gitStream will skip the automations entirely.
 
 ## Install the gitStream Service
 

--- a/docs/gitlab-installation.md
+++ b/docs/gitlab-installation.md
@@ -40,6 +40,9 @@ Create a `cm` project (repository) in your GitLab group. This repository must be
 !!! example "Example Configuration"
 		--8<-- "docs/downloads/gitStream-gl.cm"
 
+!!! warning "Explicit triggers are not supported"
+    The `triggers` and `on` functionality are not currently supported in GitLab. If you include them in your CM automation files, gitStream will skip the automations entirely.
+
 ## Create a GitLab Pipeline
 
 Once your gitStream configuration file is set up, you need a GitLab CI configuration file to trigger gitStream automations. Create a `cm` project (repository) in your GitLab group if you haven't already. It should be created in the same group or a parent group of the target repositories. Create a `.gitlab-ci.yml` file in your new `cm` repository's default branch (usually `master` or `main`) and add the following configuration:


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose and impact:
This PR updates documentation for Bitbucket and GitLab installations, clarifying limitations and adding warnings about unsupported features.

Main changes:
- Adds warning about unsupported 'triggers' and 'on' functionality in Bitbucket and GitLab
- Improves formatting and removes unnecessary whitespace
- Clarifies that labels are not supported in Bitbucket

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
