### PR TITLE
Add self-hosted runner setup docs for Bitbucket

### DIFF
--- a/docs/bitbucket-installation.md
+++ b/docs/bitbucket-installation.md
@@ -39,12 +39,13 @@ description: Install gitStream to your Bitbucket workspace.
 
     This combination ensures that both gitStream's internal operations and your CI runners' interactions with Bitbucket function without network restrictions.
 
-Bitbucket Installation Overview
+## Bitbucket Installation Overview
 
 1. Designate a gitStream user account.
 2. Create a `cm` repo and `.cm` configuration file.
 3. Create a Bitbucket pipeline.
-4. Install the gitStream service.
+4. Configure self-hosted runners (if applicable).
+5. Install the gitStream service.
 
 ## Designate a gitStream User Account
 
@@ -56,6 +57,9 @@ gitStream automation rules are executed by the user account configured when you 
 ## Create a `cm` repo and `.cm` configuration file.
 
 Create a `cm` repository in your Bitbucket workspace. This repository must reside in the same project as your target repositories. In the root directory of the default branch (usually `master` or `main`), create a `gitstream.cm` rules file to define the workflow automations. The file can have any name but must end with the `.cm` extension.
+
+!!! warning "Changes Must Be in Main Branch"
+    Ensure all changes to your `.cm` configuration files are committed to the main branch before proceeding with the setup.
 
 !!! info "Configuration File Locations"
 	Group-level rules require your `.cm` files to be placed in the `cm` repository's root directory.
@@ -74,10 +78,41 @@ Once your gitStream configuration file is set up, you need a Bitbucket Pipelines
 --8<-- "docs/downloads/bitbucket-pipelines.yml"
 ```
 
-!!! warning "Labels are not supported"
+## Configure Self-Hosted Runners (Optional)
+
+If you're using self-hosted runners for your gitStream automation, follow these additional configuration steps:
+
+**1. Self-Hosted Runner Must Be on the CM Repository**
+
+Self-hosted runners need to be configured specifically for the `cm` repository where your gitStream configuration files are stored.
+
+**2. Update Pipeline Configuration**
+
+Add the following configuration to your `bitbucket-pipelines.yml` in the gitstream custom pipeline section:
+
+```yaml
+runs-on:
+  - self.hosted # Required to indicate a self-hosted runner
+  - cmgitstreamrunner # Must use custom label for gitStream runner
+```
+
+**3. Configure Runner Labels in Bitbucket**
+
+!!! important "Required Runner Labels"
+    You MUST add the following labels to your self-hosted runner in Bitbucket:
+
+    - `self.hosted` (provided by default)
+    - `linux` (provided by default)
+    - `cmgitstreamrunner` (custom label you need to add)
+
+    The `cmgitstreamrunner` label is required for gitStream to properly identify and use your self-hosted runner.
+
+**4. Verify Runner Configuration**
+
+!!! warning "Labels are **not supported**"
     The `add-label` action is not supported in Bitbucket as Bitbucket does not have a native labeling feature.
 
-!!! warning "Explicit triggers are not supported"
+!!! warning "Explicit triggers are **not supported**"
     The `triggers` and `on` functionality are not currently supported in Bitbucket. If you include them in your CM automation files, gitStream will skip the automations entirely.
 
 ## Install the gitStream Service
@@ -86,6 +121,9 @@ To complete the setup, install the gitStream service in your Bitbucket workspace
 
 ## Next Step
 If you successfully complete these instructions, gitStream will now automate your code review workflows in Bitbucket.
+
+!!! success "Setup Complete"
+    If you successfully complete these instructions, gitStream will now automate your code review workflows in Bitbucket.
 
 !!! tip "How gitStream Works"
     Read our guide, [How gitStream Works](/how-it-works/), for a deeper understanding of gitStream's capabilities and how to leverage them fully.

--- a/docs/downloads/bitbucket-pipelines.yml
+++ b/docs/downloads/bitbucket-pipelines.yml
@@ -6,6 +6,10 @@ pipelines:
   # Pipelines that can only be triggered manually
   custom:
     gitstream:
+      # For self-hosted runners, uncomment the runs-on section below
+      # runs-on:
+      #   - self.hosted # Required to indicate a self-hosted runner
+      #   - cmgitstreamrunner # Custom label that must be added to your self-hosted runner
       - variables:
           - name: client_payload
             description: the client payload

--- a/docs/downloads/gitstream-bb.cm
+++ b/docs/downloads/gitstream-bb.cm
@@ -6,24 +6,6 @@ manifest:
 
 
 automations:
-  # Use LinearB's AI service to review the changes
-  linearb_ai_review:
-    if:
-      - {{ not is.bot }}
-    run:
-      - action: code-review@v1
-        args:
-          approve_on_LGTM: {{ calc.safe_changes }}
-
-  # Use LinearB's AI service to add a description to the PR
-  linearb_ai_description:
-    if:
-      - {{ not is.bot }}
-    run:
-      - action: describe-changes@v1
-        args:
-          concat_mode: append
-
   # Add a label indicating how long it will take to review the PR.
   estimated_time_to_review:
     if:


### PR DESCRIPTION
The changes primarily document how to configure and use self-hosted runners with gitStream in Bitbucket, along with some formatting improvements and cleanup of example files.

<img width="828" alt="Screenshot 2025-06-05 at 17 47 20" src="https://github.com/user-attachments/assets/9696b75a-483b-4c8b-99d5-69b520d63085" />
<img width="761" alt="Screenshot 2025-06-05 at 17 47 44" src="https://github.com/user-attachments/assets/f807ad0d-046b-4c17-97b2-2f563b4891a1" />
