### PR TITLE
Add code experts tip to docs

### DIFF
--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -467,6 +467,21 @@ automations:
           gt: 10
 ```
 
+!!! tip "Automatically assign code experts"
+    You can automatically assign code experts as reviewers by using the `add-reviewers` action with the `codeExperts` filter function:
+
+    ```yaml+jinja
+    automations:
+      code_experts:
+        if:
+          - true
+        run:
+          - action: add-reviewers@v1
+            args:
+              reviewers: {{ repo | codeExperts(gt=10) }}
+    ```
+
+    For more information about the `codeExperts` filter function, see the [filter functions documentation](https://docs.gitstream.cm/filter-functions/#codeexperts).
 
 #### `merge` :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
 


### PR DESCRIPTION
<img width="990" alt="Screenshot 2025-06-12 at 13 48 23" src="https://github.com/user-attachments/assets/1c677765-64bf-4e2e-bf0c-b7bef159a6de" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: This PR adds a tip about automatically assigning code experts as reviewers using the `add-reviewers` action with the `codeExperts` filter function.

Main changes:
- Adds a new tip section under the `explain-code-experts` action documentation
- Provides an example YAML snippet for automatically assigning code expert reviewers
- Includes a link to the filter functions documentation for more information

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
