### PR TITLE
in `Explicit triggers` that in the case that bith file level explict

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -36,6 +36,9 @@ gitstream supports an explicit triggering mechanism. When using explicit trigger
 
 Triggers can be defined globally at the file level or specifically for each automation. Triggers are applied only to the file(s) where they are declared.
 
+!!! Note "Combining File-Level and Automation-Level Triggers"
+    When both file-level explicit triggers and automation-level explicit triggers exist, the actual triggers used will be the result of unifying both lists. This means the automation will be triggered by any event specified in either the file-level triggers or the automation-level triggers.
+
 #### `triggers` section
 
 The `triggers` section in gitStream gives you precise control over when automations execute. It allows you to define conditions based on pull request events using `include` and `exclude` lists to specify branch and repository patterns. These lists determine which branches or repositories trigger or bypass automation but do not affect the events initiating automations.


### PR DESCRIPTION
triggers exists and automation level explict triggers, the actual triggers used will be the result of unifing both lists

<img width="761" alt="Screenshot 2025-07-02 at 14 24 39" src="https://github.com/user-attachments/assets/4a4970c1-9396-40b9-a84c-0d8d898e79cb" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Adds documentation on how file-level and automation-level triggers are unified in gitStream.

Main changes:
- Introduces a note explaining that file-level and automation-level triggers are combined through unification.
- Clarifies that automations will trigger on any event specified in either trigger list.
- Explains the behavior when both trigger types exist in the configuration.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
