### PR TITLE
fix path

### DIFF
--- a/docs/integrations/LinearBAI.md
+++ b/docs/integrations/LinearBAI.md
@@ -7,7 +7,7 @@ category: [quality, genai, copilot, tests, efficiency]
 
 !!! tip "User Commands"
 
-    LinearB's AI is available also with user commands, read more about them [here](docs/user-commands.md)
+    LinearB's AI is available also with user commands, read more about them [here](/user-commands)
 
 <!-- --8<-- [start:examples]-->
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fixed the broken link to user commands documentation in the LinearBAI integration page.

Main changes:
- Updated relative link from `[here](docs/user-commands.md)` to `[here](/user-commands)`

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
