### PR TITLE
update GL and BB instruction for service account

### DIFF
--- a/docs/bitbucket-installation.md
+++ b/docs/bitbucket-installation.md
@@ -49,7 +49,9 @@ description: Install gitStream to your Bitbucket workspace.
 
 ## Designate a gitStream User Account
 
-gitStream automation rules are executed by the user account configured when you authorize LinearB. A meaningful account identifier whose name contains the string `gitstream` (case insensitive), such as `gitStream-cm`, is required to ensure clarity and proper identification of the automated actions. This account must have the necessary permissions to the relevant repositories.
+gitStream automation rules are executed on behalf of the user account configured when you connect gitStream to your Bitbucket instance. This account must have the appropriate permissions to the relevant repositories.
+
+- A meaningful account identifier whose name contains the string `gitstream` (case insensitive), such as `gitStream-cm`, is required to ensure clarity and proper identification of the automated actions
 
 !!! tip "Use this account when you integrate gitStream"
     Make sure to use this account when authorizing Bitbucket in LinearB.

--- a/docs/gitlab-installation.md
+++ b/docs/gitlab-installation.md
@@ -42,9 +42,11 @@ GitLab Installation Overview
 
 ## Designate a gitStream User Account
 
-gitStream automation rules are executed on behalf of the user account configured when you install the gitStream service. This account must have the `maintainer` or `owner` role to the relevant repos.
+gitStream automation rules are executed on behalf of the user account configured when you connect gitStream to your GitLab instance. This account must have the appropriate permissions to the relevant repositories.
 
-We recommend creating a [dedicated service account](https://docs.gitlab.com/ee/user/profile/service_accounts.html){:target="_blank"} to control access to individual repos easily. You can also use your professional or personal GitLab account for this, which would result in all automations being executed under that account, which might also affect LinearB's metrics.
+- The account must have the `maintainer` or `owner` role to the relevant repos
+- We recommend creating a [dedicated service account](https://docs.gitlab.com/ee/user/profile/service_accounts.html){:target="_blank"} to control access to individual repos easily. A meaningful account identifier whose name contains the string `gitstream` (case insensitive), such as `gitStream-cm`, is recommended to ensure clarity and proper identification of the automated actions
+- You can also use your professional or personal GitLab account, though this would result in all automations being executed under that account, which might also affect LinearB's metrics
 
 !!! tip "Use this account when you integrate gitStream"
     Make sure to use this account when authorizing GitLab in LinearB.


### PR DESCRIPTION
<img width="1173" alt="Screenshot 2025-07-06 at 12 42 38" src="https://github.com/user-attachments/assets/bad046fc-cd1e-4ed0-b023-f6510936a6dd" />
<img width="1192" alt="Screenshot 2025-07-06 at 12 42 45" src="https://github.com/user-attachments/assets/dbb869cb-54f6-4762-a995-6fa5ca9ae522" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Standardizes and clarifies the requirements for gitStream user accounts across Bitbucket and GitLab documentation.

Main changes:
- Rewords user account execution statement to consistently use "on behalf of" terminology.
- Improves formatting by converting paragraph to bullet points for clarity.
- Adds requirement for account name to contain "gitstream" string in both docs.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
