### PR TITLE
Emphasis triggers are supported for GitHub only

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,5 +1,8 @@
 # Trigger Control
 
+!!! warning "GitHub Only Feature :fontawesome-brands-github:"
+    Explicit triggers (using `on`, `triggers.on`, `triggers.include`, and `triggers.exclude` parameters) are only supported on GitHub. Using explicit triggers in GitLab or Bitbucket will cause the automation to fail with an error. For GitLab and Bitbucket, simply omit trigger configuration to use implicit triggers automatically.
+
 gitStream is triggered on new pull requests (PRs) for repositories that have gitStream installed. Upon triggering, gitStream collects context variables and evaluates the automation rules to determine which ones are relevant.
 
 ## Organization-level rules and repository rules


### PR DESCRIPTION
<img width="1229" height="732" alt="Screenshot 2025-07-24 at 17 07 04" src="https://github.com/user-attachments/assets/d3f96b8a-4d4b-48d8-9d79-4fc0de222d9b" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add warning notice that explicit trigger functionality is only available on GitHub and will cause failures on other platforms.
Main changes:
- Added warning block specifying that trigger parameters are GitHub-only features
- Clarified that omitting trigger configuration is required for GitLab and Bitbucket platforms
- Included error behavior information for using triggers on unsupported platforms

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
