### PR TITLE
Rename `file_path` to `file_name` in automation docs

### DIFF
--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -75,7 +75,7 @@ This is a managed action, when PR updates, the existing comments added by gitStr
 | Args       | Usage | Type      | Description                         |
 | -----------|------|-----|------------------------------------------------ |
 | `comment`  | Required | String    | Sets the comment, markdown is supported, including suggestion syntax (```suggestion … ```) |
-| `file_path`  | Required | String    | The relative path to the file that necessitates the comment |
+| `file_name`  | Required | String    | The relative path to the file that necessitates the comment |
 | `start_line`  | Optional | Integer    | The line (or the first line in multi-line comment)of the blob in the pull request diff that the comment applies to. If start_line is empty, the code comment should be on the file provided |
 | `end_line`  | Optional | Integer    | For a multi-line comment, the last line of the range that your comment applies to. Must be equal to or larger than start_line |
 
@@ -89,7 +89,7 @@ automations:
     run:
       - action: add-code-comment@v1
         args:
-          file_path: <FILE>
+          file_name: <FILE>
           start_line: 20
           comment: |
             Magic! Move it to a constant variable.


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update parameter naming in automation documentation from `file_path` to `file_name` for consistency and accuracy.
Main changes:
- Renamed `file_path` parameter to `file_name` in automation-actions.md documentation
- Updated example code snippet to use the new parameter name

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
