### PR TITLE
Add documentation for new git history limiting configuration

### DIFF
--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -500,6 +500,10 @@ automations:
 
     For more information about the `codeExperts` filter function, see the [filter functions documentation](https://docs.gitstream.cm/filter-functions/#codeexperts).
 
+!!! tip "Limit git history for code experts"
+    
+    Use the [`config.git_history_since`](./cm-file.md#configgit_history_since) configuration to limit the git history analysis to commits after a specific date. This is useful for team transitions or when you want to focus on recent contributors only.
+
 #### `merge` :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
 
 Once triggered, merge the PR if possible. It can be set to wait for all checks to pass or only required ones.

--- a/docs/filter-functions.md
+++ b/docs/filter-functions.md
@@ -415,6 +415,10 @@ automations:
           reviewers: {{ repo | codeExperts(gt=10) }}
 ```
 
+!!! tip "Limit git history for code experts"
+    
+    Use the [`config.git_history_since`](./cm-file.md#configgit_history_since) configuration to limit the git history analysis to commits after a specific date. This is useful for team transitions or when you want to focus on recent contributors only.
+
 #### `decode`
 
 Decode Base64 encoded string into an object. Encoded strings are formatted: `"base64: <encoded_string>"`


### PR DESCRIPTION
<img width="888" height="633" alt="Screenshot 2025-07-31 at 14 03 50" src="https://github.com/user-attachments/assets/ac37b332-8fb9-4258-8609-87e364f64a2f" />

<img width="945" height="647" alt="Screenshot 2025-07-31 at 14 03 41" src="https://github.com/user-attachments/assets/202361cd-4aa2-4898-b147-bb0e6e17a797" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add documentation for new `git_history_since` configuration option to limit git history analysis for code expertise features.
Main changes:
- Added detailed configuration documentation with examples for the `git_history_since` parameter
- Updated configuration table to include the new git history limiting option
- Added cross-referenced tips in automation actions and filter functions documentation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
