### PR TITLE
Update Bitbucket installation docs with IP allowlisting details

### DIFF
--- a/docs/bitbucket-installation.md
+++ b/docs/bitbucket-installation.md
@@ -19,7 +19,7 @@ description: Install gitStream to your Bitbucket workspace.
         - 13.56.203.235
         - 54.151.81.98
 
-??? Info "Understanding IP Allowlisting for gitStream"
+??? Info "Advanced: IP Allowlisting for gitStream"
     When setting up IP allowlists in Bitbucket, you're specifying which source IP addresses are permitted to interact with your repositories and APIs. This affects both gitStream and your CI/CD runners.
 
     There are two primary cases where this matters for gitStream:
@@ -36,6 +36,7 @@ description: Install gitStream to your Bitbucket workspace.
 
     - Add LinearB/gitStream service IPs to your Bitbucket allowlist (listed above).
     - Use self-hosted runners or runners with static IPs so you can manage and allowlist their addresses explicitly.
+    - Add must add to your `bitbucket-pipeline.yml` `step.runtime.cloud.atlassian-ip-ranges: true`.
 
     This combination ensures that both gitStream's internal operations and your CI runners' interactions with Bitbucket function without network restrictions.
 

--- a/docs/downloads/bitbucket-pipelines.yml
+++ b/docs/downloads/bitbucket-pipelines.yml
@@ -26,10 +26,18 @@ pipelines:
             description: workspace/repo
       - step:
           name: /:\ gitstream workflow automation
-          # For self-hosted runners, uncomment the runs-on section below
+          ##### For cloud runners with IP whitelist, uncomment the section below
+          # size: 4x # Required as atlassian-ip-ranges supported only on 4x or more
+          # runtime:
+          #   cloud:
+          #     atlassian-ip-ranges: true
+          ##### End of section
+          #
+          ##### For self-hosted runners, uncomment the section below
           # runs-on:
           #   - self.hosted # Required to indicate a self-hosted runner
           #   - cmgitstreamrunner # Custom label that must be added to your self-hosted runner
+          ##### End of section
           max-time: 15
           clone:
             enabled: false


### PR DESCRIPTION
<img width="731" height="288" alt="Screenshot 2025-08-21 at 12 53 48" src="https://github.com/user-attachments/assets/052d04ca-d0a2-4bcb-84a7-6b280afbd7d3" />

<img width="772" height="392" alt="Screenshot 2025-08-21 at 12 53 52" src="https://github.com/user-attachments/assets/98d3472c-1567-4bc9-a9e7-d1f8e9f982de" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update Bitbucket installation documentation with comprehensive IP allowlisting instructions for various runner configurations.
Main changes:
- Renamed info section heading to "Advanced: IP Allowlisting for gitStream" for better categorization
- Added instruction to enable Atlassian IP ranges in bitbucket-pipeline.yml configuration
- Restructured pipeline example with clearly commented sections for both cloud and self-hosted runners

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
