### PR TITLE
Fix hyphen in code_experts command

### DIFF
--- a/docs/user-commands.md
+++ b/docs/user-commands.md
@@ -25,6 +25,6 @@ and :thumbsup: is added when the command has been successfully executed.
 | `/gs review` | :fontawesome-brands-github: | Run an AI-powered code review on this PR | Executes `code-review@v1` once on the current PR |
 | `/gs desc` | :fontawesome-brands-github: | Generate a description of the changes in this PR | Executes `describe-changes@v1` once on the current PR with `concat_mode: append` |
 | `/gs etr` | :fontawesome-brands-github: | Add estimated time to review label | Adds a label with the estimated review time based on the PR changes |
-| `/gs code-experts` | :fontawesome-brands-github: | Add a comment with codeExperts suggestion for current changes | Executes `explain_code_experts@v1` once on the current PR |
+| `/gs experts` | :fontawesome-brands-github: | Add a comment with codeExperts suggestion for current changes | Executes `explain-code-experts@v1` once on the current PR |
 | `/gs help` | :fontawesome-brands-github: | Show help message with available commands | Displays a comment with the list of all available gitStream commands |
 </div>


### PR DESCRIPTION
<img width="776" height="501" alt="Screenshot 2025-09-09 at 15 29 42" src="https://github.com/user-attachments/assets/47a92730-60be-4130-9485-bda48a25c4fd" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix command and function name inconsistencies in the gitStream documentation for code experts feature.
Main changes:
- Changed command from `/gs code-experts` to `/gs experts` for improved usability
- Updated function reference from `explain_code_experts@v1` to `explain-code-experts@v1` for consistency

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
