### PR TITLE
Add GitHub Enterprise setup instructions

### DIFF
--- a/docs/custom-github-app.md
+++ b/docs/custom-github-app.md
@@ -220,6 +220,7 @@ You can now set up gitStream for a single repo, your GitHub organization or acro
         ```yaml+jinja
         --8<-- "docs/downloads/gitstream.cm"
         ```
+
         **GitHub Actions**
 
         Once your gitStream configuration file is set up, you will need to create a Github Actions configuration file to trigger gitStream automations. Create a `.github/workflows/gitstream.yml` file in your `cm` repository's default branch (usually `master` or `main`) and add the following configuration:
@@ -255,6 +256,7 @@ You can now set up gitStream for a single repo, your GitHub organization or acro
         ```yaml+jinja
         --8<-- "docs/downloads/gitstream.cm"
         ```
+
         **GitHub Actions**
 
         Once your gitStream configuration file is set up, you will need to create a Github Actions configuration file to trigger gitStream automations. Create a `.github/workflows/gitstream.yml` file in your `cm` repository's default branch (usually `master` or `main`) and add the following configuration:
@@ -273,3 +275,12 @@ You can now set up gitStream for a single repo, your GitHub organization or acro
             │  └─ workflows/
             │     └─ gitstream.yml
             ```
+
+## 12. GitHub Enterprise Setup
+
+When running gitStream on GitHub Enterprise, you need to manually "clone" the following actions since runners don't connect to the internet:
+
+1. gitStream action: `gitstream-github-action`
+2. Official GitHub actions like: `actions/checkout`, `actions/setup-node`, `actions/github-script`, etc.
+
+You'll need to pull these actions manually so the runner can use them.


### PR DESCRIPTION
<img width="1172" height="454" alt="Screenshot 2025-09-25 at 15 32 47" src="https://github.com/user-attachments/assets/bf3ed051-6ba3-41c0-9236-9f11205c7a45" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add GitHub Enterprise setup instructions for offline runner environments requiring manual action cloning.
Main changes:
- Added new section "GitHub Enterprise Setup" with offline runner instructions
- Added clarification on manually cloning gitstream-github-action and official GitHub actions
- Improved document formatting with additional line breaks for readability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
