### PR TITLE
Remove team-specific file example from guidelines table

### DIFF
--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -351,7 +351,6 @@ is:
 |----------|-------------|----------------|---------------|
 | Repository Root Files | Guidelines file in your repository root | Place your guidelines file (e.g., `REVIEW_RULES.md`) at the root of your repository | `guidelines: {{ "./REVIEW_RULES.md" | readFile() | dump }}` |
 | CM Repository Files | Organization-wide guidelines in central CM repository | Place guidelines in your central CM repository | `guidelines: {{ "../cm/REVIEW_RULES.md" | readFile() | dump }}` |
-| Team-specific Files | Team-level guidelines in specific team repository | Place the file in the specific team repository root | `guidelines: {{ "./TEAM_REVIEW_RULES.md" | readFile() | dump }}` |
 
 The `dump` filter ensures proper YAML formatting when the file content is inserted into the configuration.
 


### PR DESCRIPTION
<img width="803" height="469" alt="Screenshot 2025-09-29 at 18 56 33" src="https://github.com/user-attachments/assets/a5d8971d-bbfe-4673-9a52-c85ebad4cfb7" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove redundant team-specific file example from guidelines table in automation-actions documentation.
Main changes:
- Removed "Team-specific Files" row from guidelines examples table as it duplicated repository root files example

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
