### PR TITLE
Add warning about GitHub app migration for managed mode

### DIFF
--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -1,5 +1,8 @@
 # Managed Mode
 
+!!! warning "GitHub App Migration"
+    If you are using the LinearB GitHub app, you should uninstall the gitStream GitHub app and use only the LinearB GitHub app. The LinearB GitHub app supports both managed and self-managed modes, where the self-managed mode is fully compatible with your existing gitStream setup.
+
 !!! tip "Setup Configuration"
     Managed Mode setup is configured entirely from the LinearB platform. You do not need to setup gitStream yourself, add any GitHub Actions, or create CM rule files - all of this is handled automatically by the LinearB platform. For detailed setup instructions, see [Managing AI Services in LinearB](https://linearb.helpdocs.io/article/hvm9neua4e-managing-ai-services-in-linear-b#ai_tools_automations).
 


### PR DESCRIPTION
<img width="1276" height="519" alt="Screenshot 2025-10-09 at 13 48 06" src="https://github.com/user-attachments/assets/fb250b1c-6401-45a2-b42a-2c64e0e24597" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add warning message about GitHub app migration requirements for users running gitStream in managed mode.
Main changes:
- Added warning banner advising users to uninstall gitStream GitHub app in favor of LinearB GitHub app
- Clarified that LinearB GitHub app supports both managed and self-managed compatibility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
