### PR TITLE
fix: remove invalid top parameter from codeExperts filter

### DIFF
--- a/docs/downloads/gitstream.cm
+++ b/docs/downloads/gitstream.cm
@@ -76,7 +76,7 @@ has:
   jira_ticket_in_desc:  {{ pr.description | includes(regex=r/\b[A-Za-z][A-Za-z0-9_]+-\d+\b/) }}
 
 who:
-  experts: {{ repo | codeExperts(gt=10, top=5) }}
+  experts: {{ repo | codeExperts(gt=10) }}
 
 is:
   bot: {{ pr.author | match(list=['github-actions','_bot_','[bot]','dependabot','gitstream-cm','prvalidation','aida-bot']) | some }}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix invalid top parameter in codeExperts filter configuration to comply with supported filter parameters and ensure correct expert identification.
Main changes:
- Removed unsupported `top=5` parameter from codeExperts filter in gitstream configuration
- Updated filter to use only valid `gt=10` parameter for code expert threshold matching

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
