### PR TITLE
docs: Add change-pr-state automation action documentation

### DIFF
--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -266,6 +266,9 @@ automations:
 
 This action, once triggered, updates the PR state between draft and ready for review.
 
+!!! note "Explicit Triggers Required for Draft PRs"
+    Since gitStream does not run on draft PRs by default, this action requires the use of [explicit triggers](execution-model.md#explicit-triggers) to function properly. Define triggers using the `on` parameter at the automation level to specify when the automation should evaluate draft PRs.
+
 <div class="filter-details" markdown=1>
 
 | Args | Usage | Type | Description |
@@ -277,7 +280,7 @@ This action, once triggered, updates the PR state between draft and ready for re
 ```yaml+jinja title="example"
 automations:
   ready_for_review:
-    # because the action is on Draft, explicit triggers must be used
+    # Explicit triggers required to work with draft PRs
     on:
       - label_added
       - pr_created

--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -28,6 +28,7 @@ For all other actions, gitStream executes the actions in the order they are list
 - [`add-reviewers`](#add-reviewers) :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
 - [`add-thread`](#add-thread) :fontawesome-brands-gitlab:
 - [`approve`](#approve) :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
+- [`change-pr-state`](#change-pr-state) :fontawesome-brands-github: :fontawesome-brands-gitlab:
 - [`close`](#close) :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
 - [`code-review`](#code-review) :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
 - [`describe-changes`](#describe-changes) :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
@@ -259,6 +260,33 @@ automations:
       - {{ source.diff.files | isFormattingChange }}
     run:
       - action: approve@v1
+```
+
+#### `change-pr-state` :fontawesome-brands-github: :fontawesome-brands-gitlab:
+
+This action, once triggered, updates the PR state between draft and ready for review.
+
+<div class="filter-details" markdown=1>
+
+| Args | Usage | Type | Description |
+| --- | --- | --- | --- |
+| `draft` | Optional | Bool | When `true`, convert the PR to Draft. When `false`, mark the PR as Ready for review. |
+
+</div>
+
+```yaml+jinja title="example"
+automations:
+  ready_for_review:
+    # because the action is on Draft, explicit triggers must be used
+    on:
+      - label_added
+      - pr_created
+    if:
+      - true
+    run:
+      - action: change-pr-state@v1
+        args:
+          draft: false
 ```
 
 #### `close` :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:


### PR DESCRIPTION
- Add change-pr-state action to overview list
- Document action parameters and usage
- Include example for converting draft PRs to ready for review
- Supports GitHub and GitLab platforms

<img width="1238" height="617" alt="image" src="https://github.com/user-attachments/assets/11e1b5d4-7d41-45c7-823d-e2eb13c10385" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add comprehensive documentation for the change-pr-state automation action, including usage patterns and platform support details.

Main changes:
- Added change-pr-state action to table of contents with GitHub and GitLab platform badges
- Documented change-pr-state action with parameter definitions, usage example, and explicit trigger requirements for draft PRs
- Included note explaining that explicit triggers are required for draft PR automation due to gitStream's default execution model

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
