### PR TITLE
fix: add comment character to YAML mode headers

### DIFF
--- a/docs/downloads/automation-library/integrations/amazon_q/comment_amazon_q_prompt.cm
+++ b/docs/downloads/automation-library/integrations/amazon_q/comment_amazon_q_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/amazon_q/label_amazon_q_by_prompt.cm
+++ b/docs/downloads/automation-library/integrations/amazon_q/label_amazon_q_by_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/claude_code/comment_claude_code_prompt.cm
+++ b/docs/downloads/automation-library/integrations/claude_code/comment_claude_code_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/claude_code/label_claude_code_by_prompt.cm
+++ b/docs/downloads/automation-library/integrations/claude_code/label_claude_code_by_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/copilot/label_copilot_by_comment.cm
+++ b/docs/downloads/automation-library/integrations/copilot/label_copilot_by_comment.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/copilot/label_copilot_by_prompt.cm
+++ b/docs/downloads/automation-library/integrations/copilot/label_copilot_by_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/cursor/comment_cursor_prompt.cm
+++ b/docs/downloads/automation-library/integrations/cursor/comment_cursor_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/cursor/label_cursor_by_prompt.cm
+++ b/docs/downloads/automation-library/integrations/cursor/label_cursor_by_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/windsurf/comment_windsurf_prompt.cm
+++ b/docs/downloads/automation-library/integrations/windsurf/comment_windsurf_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0

--- a/docs/downloads/automation-library/integrations/windsurf/label_windsurf_by_prompt.cm
+++ b/docs/downloads/automation-library/integrations/windsurf/label_windsurf_by_prompt.cm
@@ -1,4 +1,4 @@
--*- mode: yaml -*-
+# -*- mode: yaml -*-
 
 manifest:
   version: 1.0


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix YAML mode headers in automation library config files by adding comment character prefix to enable proper editor mode detection.

Main changes:
- Added `#` comment character to all nine `.cm` file headers, converting `-*- mode: yaml -*-` to `# -*- mode: yaml -*-` for valid YAML syntax
- Ensures editor mode directives are properly recognized as comments in YAML files across all integration automation configs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
