### PR TITLE
fix: remove unsupported action-level 'when' in gitstream.cm

### DIFF
--- a/docs/downloads/gitstream.cm
+++ b/docs/downloads/gitstream.cm
@@ -31,19 +31,6 @@ automations:
           label: "{{ calc.etr }} min review"
           color: {{ colors.red if (calc.etr >= 20) else (colors.yellow if (calc.etr >= 5) else colors.green) }}
 
-      - action: add-label@v1
-        when :  {{ pr.unresolved_threads }}
-        args:
-          label: "{{ pr.unresolved_threads | default(value=0) }} unresolved thread(s)"
-          color: {{ colors.yellow }}
-
-      - action: add-label@v1
-        when: {{ not (has.jira_ticket_in_title or has.jira_ticket_in_desc) }}
-        args:
-          label: "missing-jira"
-          color: {{ colors.red }}
-          # further automations available with Jira webhook
-
       # Assign reviewers silently
       - action: add-reviewers@v1
         args:
@@ -66,6 +53,31 @@ automations:
             {{ '✅ Found in title/description.' if (has.jira_ticket_in_title or has.jira_ticket_in_desc) else '⚠️ Missing Jira ticket. Please add one (e.g., `ABC-123` or an `atlassian.net/browse/...` link).' }}
 
             > Labels/reviewers were applied quietly to keep this PR clean.
+
+  pr_policy_unresolved_threads:
+    on: [pr_created, commit]
+    if:
+      - {{ not pr.draft }}
+      - {{ not is.bot }}
+      - {{ pr.unresolved_threads }}
+    run:
+      - action: add-label@v1
+        args:
+          label: "{{ pr.unresolved_threads | default(value=0) }} unresolved thread(s)"
+          color: {{ colors.yellow }}
+
+  pr_policy_missing_jira:
+    on: [pr_created, commit]
+    if:
+      - {{ not pr.draft }}
+      - {{ not is.bot }}
+      - {{ not (has.jira_ticket_in_title or has.jira_ticket_in_desc) }}
+    run:
+      - action: add-label@v1
+        args:
+          label: "missing-jira"
+          color: {{ colors.red }}
+          # further automations available with Jira webhook
 
 # ----------------- config -----------------
 calc:


### PR DESCRIPTION
## Summary

- `when` is not a supported key at the action level in gitStream CM files
- Removed `when` from two `add-label@v1` actions in `pr_policy_low_noise`
- Extracted each into its own automation with the condition properly placed in `if`:
  - `pr_policy_unresolved_threads` — labels PRs with open threads
  - `pr_policy_missing_jira` — labels PRs missing a Jira ticket reference

## Test plan

- [ ] Verify `gitstream.cm` parses without errors
- [ ] Confirm `pr_policy_unresolved_threads` only triggers when `pr.unresolved_threads` is truthy
- [ ] Confirm `pr_policy_missing_jira` only triggers when no Jira ticket is found in title or description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix gitstream configuration by removing unsupported action-level 'when' clauses and refactoring conditional label actions into separate automation rules.

Main changes:
- Removed invalid 'when' clauses from add-label actions that were causing configuration errors in gitstream.cm
- Extracted unresolved threads and missing JIRA label logic into dedicated automation rules with proper if conditions
- Moved conditional labeling from inline action filters to automation-level if blocks for proper gitstream syntax compliance

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
