### PR TITLE
docs: update isFormattingChange supported file types

### DIFF
--- a/docs/filter-functions.md
+++ b/docs/filter-functions.md
@@ -865,9 +865,9 @@ run:
 
 #### `isFormattingChange`
 
-Return `true` if all file diffs are validated as formatting changes. This filter function works for JavaScript, TypeScript, Python, JSON, YAML and HTML.
+Return `true` if all file diffs are validated as formatting changes. This filter function works for JavaScript, TypeScript, JSX, TSX, Python, JSON, YAML, HTML, CSS, SCSS, LESS, Markdown, and other file types supported by Prettier.
 
-gitStream determines formatting changes by minifying the source code for the incoming changes and the existing code and comparing them. If they are identical, this filter function returns `true`. If any unsupported languages are contained in the PR, gitStream will return `false`.
+gitStream determines formatting changes by minifying the source code for the incoming changes and the existing code and comparing them. If they are identical, this filter function returns `true`. For unsupported file types, gitStream falls back to whitespace normalization for comparison.
 
 <div class="filter-details" markdown=1>
 


### PR DESCRIPTION
## Summary

- Updated supported file types list to include CSS, SCSS, LESS, Markdown, JSX, TSX
- Updated behavior for unsupported types: falls back to whitespace normalization instead of returning false
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Expand `isFormattingChange` documentation to include additional supported file types and clarify fallback behavior for unsupported formats.

Main changes:
- Added CSS, SCSS, LESS, Markdown, and Prettier-supported file types to documentation
- Updated fallback behavior description from returning `false` to whitespace normalization approach

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
