### PR TITLE
Update gitStream Playground links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Our research shows that code reviews are [the most consistent bottleneck in the 
 
 ## 🚀 Get Started
 
-gitStream is a GitHub / GitLab / Bitbucket app that processes automations defined in Continuous Merge (CM) automation files contained in your git repos. You can test gitStream automations on your own PRs via the [gitStream playground](https://app.gitstream.cm/playground).
+gitStream is a GitHub / GitLab / Bitbucket app that processes automations defined in Continuous Merge (CM) automation files contained in your git repos. You can test gitStream automations on your own PRs via the [gitStream playground](https://app.linearb.io/automations/playground).
 
 If you're ready to install gitStream, or want to explore its automation capabilities, [head over to the docs](https://docs.gitstream.cm). You can have your first automation up and running in as little as 2 minutes.
 

--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -429,7 +429,7 @@ automations:
 
     To achieve the exact review behavior you want, use this iterative workflow:
 
-    1. Start with the [Playground](https://app.gitstream.cm/playground)
+    1. Start with the [Playground](https://app.linearb.io/automations/playground)
     2. Add specific guidelines e.g., "Do not comment on formatting issues"
     3. Run in the Playground with a reference PR from your repository
     4. Refine guidelines based on the results

--- a/docs/gitStream-playground.md
+++ b/docs/gitStream-playground.md
@@ -1,12 +1,12 @@
 Welcome to gitStream Playground! This platform allows you to thoroughly test gitStream automations before deploying them into the `.cm` rule file on any GitHub pull request of your choice. 
 
-[Playground :fontawesome-solid-play:](https://app.gitstream.cm/playground){.md-button .md-button--primary}
+[Playground :fontawesome-solid-play:](https://app.linearb.io/automations/playground){.md-button .md-button--primary}
 
 ## Getting Started
 
 ### Accessing gitStream Playground
 
-To access gitStream Playground, visit [https://app.gitstream.cm/playground](https://app.gitstream.cm/playground). 
+To access gitStream Playground, visit [https://app.linearb.io/automations/playground](https://app.linearb.io/automations/playground).
 To be able to test automations of private repository PRs, log in with your GitHub account credentials.
 
 ### Interface Overview

--- a/docs/plugins-for-developers.md
+++ b/docs/plugins-for-developers.md
@@ -208,7 +208,7 @@ Filter function plugins can accept any number of arguments. The first argument m
 
 2. **Context Variable Insight**
 
-    Utilize the [gitStream playground](https://app.gitstream.cm/playground) to see how the context variable appears in a real Pull Request (PR). Inspect the PR Context Variables at the bottom of the screen ![Playground](screenshots/playground-context-variables.png).
+    Utilize the [gitStream playground](https://app.linearb.io/automations/playground) to see how the context variable appears in a real Pull Request (PR). Inspect the PR Context Variables at the bottom of the screen ![Playground](screenshots/playground-context-variables.png).
 
 3. **Local Execution**
 


### PR DESCRIPTION
Updates all gitStream Playground links from the old `app.gitstream.cm/playground` URL to the new LinearB Automations Playground URL: `https://app.linearb.io/automations/playground`
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update gitStream Playground URLs from gitstream.cm domain to linearb.io across documentation and README files.

Main changes:
- Replace all playground links from https://app.gitstream.cm/playground to https://app.linearb.io/automations/playground in four documentation files
- Update README introduction and automation-actions.md workflow references with new playground URL
- Update gitStream-playground.md and plugins-for-developers.md documentation with corrected playground endpoint

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
