### PR TITLE
Add Label Missing Jira Info section to Managed Mode docs

### DIFF
--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -97,20 +97,17 @@ Label PRs that don't reference a Jira ticket in the title, description, or branc
 
 ```yaml
 automations:
-  linearb_label_missing_jira_info:
+  label_missing_jira_info:
     if:
       - {{ not (pr.title       | includes(regex=r/\b[A-Za-z]+-\d+\b/)) }}
       - {{ not (pr.description | includes(regex=r/atlassian.net\/browse\/\w{1,}-\d{3,4}/)) }}
-      - {{ not (pr.source      | includes(regex=r/[A-Z]+-\d+/)) }}
+      - {{ not (pr.source      | includes(regex=r/\b[A-Za-z]+-\d+\b/)) }}
       - {{ not is.bot_author }}
     run:
       - action: add-label@v1
         args:
           label: "missing-jira"
           color: 'F6443B'
-
-is:
-  bot_author: {{ pr.author | match(list=["github-actions", "_bot_", "[bot]", "dependabot"]) | some }}
 ```
 
 ### Estimated Time to Review

--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -110,7 +110,7 @@ automations:
           color: 'F6443B'
 
 missing_jira_ticket_on_title:       {{ pr.title       | capture(regex=r/\b[A-Za-z]+-\d+\b/) | length == 0 }}
-missing_jira_ticket_on_description: {{ pr.description | capture(regex=r/atlassian.net\/browse\/\w{1,}-\d+/) | length == 0 }}
+missing_jira_ticket_on_description: {{ pr.description | capture(regex=r/atlassian\.net\/browse\/\w{1,}-\d+/) | length == 0 }}
 missing_jira_ticket_on_branch:      {{ pr.source      | capture(regex=r/\b[A-Za-z]+-\d+\b/) | length == 0 }}
 missing_jira_ticket: {{ missing_jira_ticket_on_title and missing_jira_ticket_on_description and missing_jira_ticket_on_branch }}
 ```

--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -100,7 +100,7 @@ automations:
   label_missing_jira_info:
     if:
       - {{ not (pr.title       | includes(regex=r/\b[A-Za-z]+-\d+\b/)) }}
-      - {{ not (pr.description | includes(regex=r/atlassian.net\/browse\/\w{1,}-\d{3,4}/)) }}
+      - {{ not (pr.description | includes(regex=r/atlassian.net\/browse\/\w{1,}-\d+/)) }}
       - {{ not (pr.source      | includes(regex=r/\b[A-Za-z]+-\d+\b/)) }}
       - {{ not is.bot_author }}
     run:

--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -98,8 +98,6 @@ Label PRs that don't reference a Jira ticket in the title, description, or branc
 ```yaml
 automations:
   label_missing_jira_info:
-    # Triggered for PRs that don't have a Jira ticket reference in the title,
-    # description, or branch name.
     if:
       - {{ missing_jira_ticket }}
       - {{ not is.bot_author }}

--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -91,6 +91,28 @@ is:
   linearb_co_author: {{ branch.commits.messages | match(regex=r/[Cc]o-[Aa]uthored-[Bb]y:.*(gitstream-cm|linearb).*\[bot\]/) | some }}
 ```
 
+### Label Missing Jira Info
+
+Label PRs that don't reference a Jira ticket in the title, description, or branch name. This uses configurable regular expressions to detect Jira ticket formats; PRs that fail all three checks receive a `missing-jira` label. The title regex, description regex, branch regex, and label name can all be customized per organization from the LinearB platform.
+
+```yaml
+automations:
+  linearb_label_missing_jira_info:
+    if:
+      - {{ not (pr.title       | includes(regex=r/\b[A-Za-z]+-\d+\b/)) }}
+      - {{ not (pr.description | includes(regex=r/atlassian.net\/browse\/\w{1,}-\d{3,4}/)) }}
+      - {{ not (pr.source      | includes(regex=r/[A-Z]+-\d+/)) }}
+      - {{ not is.bot_author }}
+    run:
+      - action: add-label@v1
+        args:
+          label: "missing-jira"
+          color: 'F6443B'
+
+is:
+  bot_author: {{ pr.author | match(list=["github-actions", "_bot_", "[bot]", "dependabot"]) | some }}
+```
+
 ### Estimated Time to Review
 
 Label all PRs with an estimated number of minutes it would take someone to review. gitStream automatically updates this label whenever a PR changes, providing valuable insight for reviewers and team planning.

--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -98,16 +98,21 @@ Label PRs that don't reference a Jira ticket in the title, description, or branc
 ```yaml
 automations:
   label_missing_jira_info:
+    # Triggered for PRs that don't have a Jira ticket reference in the title,
+    # description, or branch name.
     if:
-      - {{ not (pr.title       | includes(regex=r/\b[A-Za-z]+-\d+\b/)) }}
-      - {{ not (pr.description | includes(regex=r/atlassian.net\/browse\/\w{1,}-\d+/)) }}
-      - {{ not (pr.source      | includes(regex=r/\b[A-Za-z]+-\d+\b/)) }}
+      - {{ missing_jira_ticket }}
       - {{ not is.bot_author }}
     run:
       - action: add-label@v1
         args:
           label: "missing-jira"
           color: 'F6443B'
+
+missing_jira_ticket_on_title:       {{ pr.title       | capture(regex=r/\b[A-Za-z]+-\d+\b/) | length == 0 }}
+missing_jira_ticket_on_description: {{ pr.description | capture(regex=r/atlassian.net\/browse\/\w{1,}-\d+/) | length == 0 }}
+missing_jira_ticket_on_branch:      {{ pr.source      | capture(regex=r/\b[A-Za-z]+-\d+\b/) | length == 0 }}
+missing_jira_ticket: {{ missing_jira_ticket_on_title and missing_jira_ticket_on_description and missing_jira_ticket_on_branch }}
 ```
 
 ### Estimated Time to Review


### PR DESCRIPTION
## Summary

- Adds a `### Label Missing Jira Info` section to `docs/managed-mode.md`.
- Documents the productized Managed Mode variant — three configurable regex checks (title, description, branch name) plus a configurable label name.
- Makes the anchor `https://docs.gitstream.cm/managed-mode/#label-missing-jira-info` valid for the upcoming LinearB platform catalog entry that links here.

Part of LINBEE-24474 (productizing the Label Missing Jira Info automation in Managed Mode).

## Test plan

- [ ] `mkdocs serve` locally and confirm the new section renders correctly and the anchor `#label-missing-jira-info` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add documentation section explaining Jira ticket validation automation for detecting and labeling PRs missing ticket references.

Main changes:
- Added "Label Missing Jira Info" section with YAML automation configuration using regex patterns for title, description, and branch detection
- Documented three configurable regex checks combined with logical AND condition to identify missing Jira ticket references

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
