### PR TITLE
fix: use \w+ instead of \w{1,} in Label Missing Jira Info description regex [skip-ci]

### DIFF
--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -108,7 +108,7 @@ automations:
           color: 'F6443B'
 
 missing_jira_ticket_on_title:       {{ pr.title       | capture(regex=r/\b[A-Za-z]+-\d+\b/) | length == 0 }}
-missing_jira_ticket_on_description: {{ pr.description | capture(regex=r/atlassian\.net\/browse\/\w{1,}-\d+/) | length == 0 }}
+missing_jira_ticket_on_description: {{ pr.description | capture(regex=r/atlassian\.net\/browse\/\w+-\d+/) | length == 0 }}
 missing_jira_ticket_on_branch:      {{ pr.source      | capture(regex=r/\b[A-Za-z]+-\d+\b/) | length == 0 }}
 missing_jira_ticket: {{ missing_jira_ticket_on_title and missing_jira_ticket_on_description and missing_jira_ticket_on_branch }}
 ```


### PR DESCRIPTION
## Summary
- Replaces `\w{1,}` with `\w+` in the description regex example. Same regex semantically; sidesteps a YAML/template serialization issue in the pipeline.

The pipeline's `buildCMYaml` post-process regex `/'(\{\{[^}]+\}\})'/` is meant to strip the single-quotes that `js-yaml` adds around any template containing `{`. With `\w{1,}` the cleanup fails because `[^}]+` stops at the inner `}` of `{1,}`. The engine then receives a quoted string instead of a template expression, emits *"expected a boolean or a numeric value under `if`"*, and the check returns `"true"` (string) instead of `true` (boolean), breaking the missing-jira label rule.

Verified against `niv-organization/swell-essentials#194` on dev-01: with `\w{1,}` the description check returned a string + syntax warning; with `\w+` it round-trips cleanly.

## Test plan
- [x] Confirm same matches: `\w+` ≡ `\w{1,}` for any string
- [x] Reproduce on dev-01 pipeline before fix (syntax warning emitted)
- [x] Confirm cmBuilder snapshot updated in pipeline PR linear-b/gitstream-sls-pipeline#2829
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix regex pattern in Jira ticket detection to use standard quantifier syntax for better compatibility and clarity.

Main changes:
- Changed `\w{1,}` to `\w+` in description regex pattern for matching Jira project keys

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
