### PR TITLE
[codex] Document ignored blame revisions for code experts

### DIFF
--- a/docs/automation-actions.md
+++ b/docs/automation-actions.md
@@ -545,6 +545,8 @@ is:
 
 This action, shall add a comment with codeExperts suggestion. If the comment already exists, the comment shall be edited.
 
+The underlying blame-based expertise calculation respects a repository-level `.git-blame-ignore-revs` file. Use this Git file to keep formatting-only commits or mechanical migrations from dominating code expert attribution.
+
 <div class="filter-details" markdown=1>
 
 | Args       | Usage | Type      | Description                                     |
@@ -582,9 +584,11 @@ automations:
 
     For more information about the `codeExperts` filter function, see the [filter functions documentation](https://docs.gitstream.cm/filter-functions/#codeexperts).
 
-!!! tip "Limit git history for code experts"
+!!! tip "Control code expert attribution"
 
     Use the [`config.git_history_since`](./cm-file.md#configgit_history_since) configuration to limit the git history analysis to commits after a specific date. This is useful for team transitions or when you want to focus on recent contributors only.
+
+    Use `.git-blame-ignore-revs` when you need to exclude specific commits from blame attribution. This is different from [`config.ignore_files`](./cm-file.md#configignore_files), which excludes whole files from automation processing.
 
 #### `merge` :fontawesome-brands-github: :fontawesome-brands-gitlab: :fontawesome-brands-bitbucket:
 

--- a/docs/automations/standard/explain-code-experts/README.md
+++ b/docs/automations/standard/explain-code-experts/README.md
@@ -8,6 +8,8 @@ quickstart: true
 
 Post a comment that uses git blame and history to list the most relevant experts for all PRs. The comment will automatically update as additional commits are added to the PR.
 
+If your repository has formatting-only commits or mechanical migrations that should not count toward expertise, list those commit SHAs in `.git-blame-ignore-revs`. The blame-based calculation used by this automation excludes those revisions from code expert attribution.
+
 <div class="automationImage" markdown="1">
 ![Explain Code Experts](explain-code-experts.png)
 </div>

--- a/docs/filter-functions.md
+++ b/docs/filter-functions.md
@@ -480,6 +480,12 @@ The output lists the Git provider users, e.g., GitHub users, which are mapped fr
 
     The `codeExperts` filter function calls gitStream app API with the `repo` context to calculate the experts.
 
+!!! note "Ignored blame revisions"
+
+    `codeExperts` respects a repository-level `.git-blame-ignore-revs` file when calculating blame-based expertise. Use this Git file to exclude specific commits, such as formatting-only commits or mechanical migrations, from blame attribution.
+
+    This is different from [`config.git_history_since`](./cm-file.md#configgit_history_since), which limits history analysis by date, and [`config.ignore_files`](./cm-file.md#configignore_files), which excludes whole files from automation processing.
+
 <div class="filter-details" markdown=1>
 
 | Argument       | Usage    | Type   | Description                                     |
@@ -806,6 +812,8 @@ This filter helps to explain the results of [`rankByGitBlame`](#rankbygitblame),
 
 The output lists the Git provider users, e.g., GitHub users, which are mapped from the Git users included in the `git-blame` output. Git users that could not be automatically mapped are marked with `*`. To map these users, you can add `user_mapping` see instructions [here](/cm-file#config).
 
+`explainRankByGitBlame` respects a repository-level `.git-blame-ignore-revs` file. Commits listed there are excluded from blame attribution before contributor percentages are calculated.
+
 <div class="filter-details" markdown=1>
 
 | Argument       | Usage    | Type   | Description                                     |
@@ -977,6 +985,8 @@ The `repo` context includes all the changed files, for each file it includes the
 contributors' percentage of lines in the file, based on `git-blame`.
 
 This function sums all these percentages per user and yield an average percentage of contribution. Then you can use the thresholds to get the right reviewer.
+
+`rankByGitBlame` respects a repository-level `.git-blame-ignore-revs` file. Commits listed there are excluded from blame attribution before contributor percentages are calculated.
 
 The output lists the Git provider users, e.g., GitHub users, which are mapped from the Git users included in the `git-blame` output. When gitStream cannot map the Git user to a Git provider user it will be dropped from the output list, hence the list may contain less than 100% of the lines.
 


### PR DESCRIPTION
## Summary
- Document that code expert and blame-based reviewer calculations respect .git-blame-ignore-revs
- Clarify when to use .git-blame-ignore-revs instead of config.git_history_since or config.ignore_files
- Add the note to the explain code experts automation page and action reference

<img width="1197" height="530" alt="image" src="https://github.com/user-attachments/assets/0fe161e3-b1dd-436a-9ea6-ce60a6972a31" />
<img width="881" height="384" alt="image" src="https://github.com/user-attachments/assets/08b4bdce-cf22-452c-bd7c-8dcbf6da7d8f" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Document `.git-blame-ignore-revs` support across code expert and blame-based filter functions to exclude formatting and mechanical commits.

Main changes:
- Added `.git-blame-ignore-revs` documentation to `codeExperts`, `rankByGitBlame`, and `explainRankByGitBlame` filter functions
- Updated automation documentation with tip section distinguishing `.git-blame-ignore-revs` from `config.git_history_since` and `config.ignore_files`
- Added `.git-blame-ignore-revs` guidance to explain-code-experts automation README with usage example

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
