### PR TITLE
fix: set dind MTU in the GitLab-hosted CI template [LINBEE-27634]

### DIFF
--- a/docs/downloads/gitlab-ci.yml
+++ b/docs/downloads/gitlab-ci.yml
@@ -11,6 +11,7 @@ image: docker:latest
 
 services:
   - name: docker:dind
+    command: ["--mtu=1360"]
 
 before_script:
   - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Configure the Maximum Transmission Unit (MTU) for Docker-in-Docker services in the GitLab CI template.

Main changes:
- Added `--mtu=1360` command argument to the `docker:dind` service configuration.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
