### PR TITLE
fix: fetch all branch heads so gitStream can diff non-default base branches

### DIFF
--- a/docs/downloads/bitbucket-pipelines.yml
+++ b/docs/downloads/bitbucket-pipelines.yml
@@ -40,7 +40,13 @@ pipelines:
           script:
             - git clone --shallow-since="6 months ago" --no-tags https://x-token-auth:$oauth_token@bitbucket.org/$full_repo.git gitstream/repo
             - git clone --depth=1 --no-tags https://x-token-auth:$oauth_token@bitbucket.org/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG.git gitstream/cm
-            - cd gitstream/repo && git fetch origin $head_ref:$head_ref && git checkout $head_ref
+            - |
+              set -e
+              cd gitstream/repo
+              git checkout --detach
+              # Fetch all branches so any base branch can be diffed; keep --shallow-since or this pulls full history.
+              git fetch --no-tags --force --shallow-since="6 months ago" origin '+refs/heads/*:refs/heads/*'
+              git checkout "$head_ref"
             - docker pull gitstream/rules-engine:latest
             - |
               docker run -v $BITBUCKET_CLONE_DIR/gitstream:/code \

--- a/docs/downloads/gitlab-ci.yml
+++ b/docs/downloads/gitlab-ci.yml
@@ -27,7 +27,13 @@ gitstream-job:
   script:
     - git clone --shallow-since="6 months ago" --no-tags https://gitlab-ci-token:${CI_JOB_TOKEN}${repoUrl} gitstream/repo
     - git clone --depth=1 --no-tags https://gitlab-ci-token:${CI_JOB_TOKEN}${cmUrl} gitstream/cm
-    - cd gitstream/repo && git fetch origin $head_ref:$head_ref && git checkout $head_ref
+    - |
+      set -e
+      cd gitstream/repo
+      git checkout --detach
+      # Fetch all branches so any base branch can be diffed; keep --shallow-since or this pulls full history.
+      git fetch --no-tags --force --shallow-since="6 months ago" origin '+refs/heads/*:refs/heads/*'
+      git checkout "$head_ref"
     - docker pull gitstream/rules-engine:latest
     - |
       docker run -v $CI_PROJECT_DIR/gitstream:/code \

--- a/docs/downloads/gitlab-k8s-ci.yml
+++ b/docs/downloads/gitlab-k8s-ci.yml
@@ -26,7 +26,13 @@ gitstream-job:
   script:
     - git clone --shallow-since="6 months ago" --no-tags https://gitlab-ci-token:${CI_JOB_TOKEN}${repoUrl} gitstream/repo
     - git clone --depth=1 --no-tags https://gitlab-ci-token:${CI_JOB_TOKEN}${cmUrl} gitstream/cm
-    - cd gitstream/repo && git fetch origin $head_ref:$head_ref && git checkout $head_ref
+    - |
+      set -e
+      cd gitstream/repo
+      git checkout --detach
+      # Fetch all branches so any base branch can be diffed; keep --shallow-since or this pulls full history.
+      git fetch --no-tags --force --shallow-since="6 months ago" origin '+refs/heads/*:refs/heads/*'
+      git checkout "$head_ref"
     - docker pull gitstream/rules-engine:latest
     - |
       docker run -v $CI_PROJECT_DIR/gitstream:/code \

--- a/docs/downloads/gitlab-shell-ci.yml
+++ b/docs/downloads/gitlab-shell-ci.yml
@@ -20,7 +20,13 @@ gitstream-job:
   script:
     - git clone --shallow-since="6 months ago" --no-tags https://gitlab-ci-token:${CI_JOB_TOKEN}${repoUrl} gitstream/repo
     - git clone --depth=1 --no-tags https://gitlab-ci-token:${CI_JOB_TOKEN}${cmUrl} gitstream/cm
-    - cd gitstream/repo && git fetch origin $head_ref:$head_ref && git checkout $head_ref
+    - |
+      set -e
+      cd gitstream/repo
+      git checkout --detach
+      # Fetch all branches so any base branch can be diffed; keep --shallow-since or this pulls full history.
+      git fetch --no-tags --force --shallow-since="6 months ago" origin '+refs/heads/*:refs/heads/*'
+      git checkout "$head_ref"
     - docker pull gitstream/rules-engine:latest
     - |
       docker run -v $CI_PROJECT_DIR/gitstream:/code \


### PR DESCRIPTION
The shallow clone implies `--single-branch`, so only the default branch is fetched. Any PR whose base is a non-default branch fails `git diff <base>...<head>` with a bad revision, which surfaces as a misleading `PR branch was deleted — run skipped` (green check, no automations run).

Reported in [CS-7247](https://linearb.atlassian.net/browse/CS-7247).
https://linearb.atlassian.net/browse/LINBEE-28439
## Changes

- Detach HEAD, then fetch all branch heads with the same `--shallow-since` bound, in all 4 templates (Bitbucket + 3 GitLab variants)
- `set -e` so a failed fetch aborts the step (the old `&&` chain was fail-fast; a multi-line block is not)

Clone line unchanged, so the 6-month history bound is preserved.

## Validation

Reproduced and fixed on `linear-b/gitstream-sanity`, same PR before and after:

| PR | base | before | after |
|---|---|---|---|
| #30668 | non-default | `PR branch was deleted — run skipped`, 1 check | `gitstream success`, 5 checks |
| #30669 | default (control) | `gitstream success` | `gitstream success` |

Also fixes a second case: a PR whose head is the default branch previously died on `refusing to fetch into branch 'refs/heads/main' checked out at ...`.

Equivalent change already merged to `linear-b/cm` and verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CS-7247]: https://linearb.atlassian.net/browse/CS-7247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enable diffing against non-default base branches by fetching all branch heads in CI pipelines.

Main changes:
- Updated Bitbucket and GitLab CI YAMLs to fetch all remote branch references
- Implemented `git fetch` with `+refs/heads/*:refs/heads/*` and `--shallow-since` for efficiency
- Added explicit `git checkout --detach` and `set -e` for improved execution reliability

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
